### PR TITLE
Fix Version Registration

### DIFF
--- a/plugin/config/detekt-baseline.xml
+++ b/plugin/config/detekt-baseline.xml
@@ -2,17 +2,11 @@
 <SmellBaseline>
   <ManuallySuppressedIssues></ManuallySuppressedIssues>
   <CurrentIssues>
-    <ID>FunctionReturnTypeSpacing:ResolutionStrategy.kt$ResolutionStrategy$override fun getDependencySubstitutionRule(): ImmutableActionSet&lt;DependencySubstitutionInternal&gt;</ID>
     <ID>TooManyFunctions:Generator.kt$Generator</ID>
     <ID>TrailingCommaOnDeclarationSite:DependencyHandler.kt$DependencyHandler$( configurationName: String, dependencyNotation: Any )</ID>
     <ID>TrailingCommaOnDeclarationSite:DependencyHandler.kt$DependencyHandler$( configurationName: String, dependencyNotation: Provider&lt;T&gt; )</ID>
     <ID>TrailingCommaOnDeclarationSite:DependencyHandler.kt$DependencyHandler$( dependencyProvider: Provider&lt;MinimalExternalModuleDependency&gt; )</ID>
     <ID>TrailingCommaOnDeclarationSite:DependencyHandler.kt$DependencyHandler$( notation: Any, configureClosure: Closure&lt;*&gt; )</ID>
-    <ID>TrailingCommaOnDeclarationSite:ResolutionStrategy.kt$ResolutionStrategy$( action: Action&lt;in CapabilitiesResolution&gt; )</ID>
-    <ID>TrailingCommaOnDeclarationSite:ResolutionStrategy.kt$ResolutionStrategy$( action: Action&lt;in ComponentSelectionRules&gt; )</ID>
-    <ID>TrailingCommaOnDeclarationSite:ResolutionStrategy.kt$ResolutionStrategy$( action: Action&lt;in DependencySubstitutions&gt; )</ID>
-    <ID>TrailingCommaOnDeclarationSite:ResolutionStrategy.kt$ResolutionStrategy$( rule: Action&lt;in DependencyResolveDetails&gt; )</ID>
-    <ID>TrailingCommaOnDeclarationSite:ResolutionStrategy.kt$ResolutionStrategy$( vararg moduleVersionSelectorNotations: Any? )</ID>
     <ID>UnnecessaryParenthesesBeforeTrailingLambda:DependencyHandler.kt$DependencyHandler$()</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/plugin/src/test/resources/expectations/spring-boot-dependencies/libs.versions.toml
+++ b/plugin/src/test/resources/expectations/spring-boot-dependencies/libs.versions.toml
@@ -1,25 +1,10 @@
 [versions]
 activemq = "5.18.2"
 assertj = "3.24.2"
-awsjavasdk = "2.21.21"
 brave = "5.15.1"
 caffeine = "3.1.6"
 dropwizardMetrics = "4.2.19"
-jacksonAnnotations = "2.15.2"
 jacksonBom = "2.15.2"
-jacksonCore = "2.15.2"
-jacksonDatabind = "2.15.2"
-jacksonDataformat = "2.15.2"
-jacksonDatatype = "2.15.2"
-jacksonJaxrs = "2.15.2"
-jacksonJacksonjr = "2.15.2"
-jacksonJakartaRs = "2.15.2"
-jacksonModule = "2.15.2"
-jacksonModuleKotlin = "2.15.2"
-jacksonModuleScala = "2.15.2"
-zipkin = "2.23.2"
-zipkinProto3 = "1.0.0"
-zipkinReporter = "2.16.3"
 
 [libraries]
 activemq-activemqBroker = { group = "org.apache.activemq", name = "activemq-broker", version.ref = "activemq" }
@@ -30,10 +15,10 @@ assertj-assertjBom = { group = "org.assertj", name = "assertj-bom", version.ref 
 assertj-assertjCore = { group = "org.assertj", name = "assertj-core", version = "3.24.2" }
 assertj-assertjGuava = { group = "org.assertj", name = "assertj-guava", version = "3.24.2" }
 awssdk-bom = { group = "software.amazon.awssdk", name = "bom", version = "2.21.21" }
-awssdk-sdkCore = { group = "software.amazon.awssdk", name = "sdk-core", version.ref = "awsjavasdk" }
-awssdk-s3 = { group = "software.amazon.awssdk", name = "s3", version.ref = "awsjavasdk" }
-awssdk-sqs = { group = "software.amazon.awssdk", name = "sqs", version.ref = "awsjavasdk" }
-awssdk-sts = { group = "software.amazon.awssdk", name = "sts", version.ref = "awsjavasdk" }
+awssdk-sdkCore = { group = "software.amazon.awssdk", name = "sdk-core", version = "2.21.21" }
+awssdk-s3 = { group = "software.amazon.awssdk", name = "s3", version = "2.21.21" }
+awssdk-sqs = { group = "software.amazon.awssdk", name = "sqs", version = "2.21.21" }
+awssdk-sts = { group = "software.amazon.awssdk", name = "sts", version = "2.21.21" }
 spring-springBoot = { group = "org.springframework.boot", name = "spring-boot", version = "3.1.2" }
 spring-springBootDevtools = { group = "org.springframework.boot", name = "spring-boot-devtools", version = "3.1.2" }
 spring-springBootStarterActuator = { group = "org.springframework.boot", name = "spring-boot-starter-actuator", version = "3.1.2" }
@@ -48,44 +33,30 @@ caffeine-caffeine = { group = "com.github.ben-manes.caffeine", name = "caffeine"
 caffeine-guava = { group = "com.github.ben-manes.caffeine", name = "guava", version.ref = "caffeine" }
 caffeine-jcache = { group = "com.github.ben-manes.caffeine", name = "jcache", version.ref = "caffeine" }
 jackson-jacksonBom = { group = "com.fasterxml.jackson", name = "jackson-bom", version.ref = "jacksonBom" }
-jackson-jacksonAnnotations = { group = "com.fasterxml.jackson.core", name = "jackson-annotations", version.ref = "jacksonAnnotations" }
-jackson-jacksonCore = { group = "com.fasterxml.jackson.core", name = "jackson-core", version.ref = "jacksonCore" }
-jackson-jacksonDatabind = { group = "com.fasterxml.jackson.core", name = "jackson-databind", version.ref = "jacksonDatabind" }
-jackson-jacksonDataformatAvro = { group = "com.fasterxml.jackson.dataformat", name = "jackson-dataformat-avro", version.ref = "jacksonDataformat" }
-jackson-jacksonDatatypeJdk8 = { group = "com.fasterxml.jackson.datatype", name = "jackson-datatype-jdk8", version.ref = "jacksonDatatype" }
-jackson-jacksonDatatypeJsr310 = { group = "com.fasterxml.jackson.datatype", name = "jackson-datatype-jsr310", version.ref = "jacksonDatatype" }
-jackson-jacksonJaxrsBase = { group = "com.fasterxml.jackson.jaxrs", name = "jackson-jaxrs-base", version.ref = "jacksonJaxrs" }
-jackson-jacksonJakartaRsBase = { group = "com.fasterxml.jackson.jakarta.rs", name = "jackson-jakarta-rs-base", version.ref = "jacksonJakartaRs" }
-jackson-jacksonJrAll = { group = "com.fasterxml.jackson.jr", name = "jackson-jr-all", version.ref = "jacksonJacksonjr" }
-jackson-jacksonModuleBlackbird = { group = "com.fasterxml.jackson.module", name = "jackson-module-blackbird", version.ref = "jacksonModule" }
-jackson-jacksonModuleKotlin = { group = "com.fasterxml.jackson.module", name = "jackson-module-kotlin", version.ref = "jacksonModuleKotlin" }
-jackson-jacksonModuleScala_211 = { group = "com.fasterxml.jackson.module", name = "jackson-module-scala_2.11", version.ref = "jacksonModuleScala" }
+jackson-jacksonAnnotations = { group = "com.fasterxml.jackson.core", name = "jackson-annotations", version = "2.15.2" }
+jackson-jacksonCore = { group = "com.fasterxml.jackson.core", name = "jackson-core", version = "2.15.2" }
+jackson-jacksonDatabind = { group = "com.fasterxml.jackson.core", name = "jackson-databind", version = "2.15.2" }
+jackson-jacksonDataformatAvro = { group = "com.fasterxml.jackson.dataformat", name = "jackson-dataformat-avro", version = "2.15.2" }
+jackson-jacksonDatatypeJdk8 = { group = "com.fasterxml.jackson.datatype", name = "jackson-datatype-jdk8", version = "2.15.2" }
+jackson-jacksonDatatypeJsr310 = { group = "com.fasterxml.jackson.datatype", name = "jackson-datatype-jsr310", version = "2.15.2" }
+jackson-jacksonJaxrsBase = { group = "com.fasterxml.jackson.jaxrs", name = "jackson-jaxrs-base", version = "2.15.2" }
+jackson-jacksonJakartaRsBase = { group = "com.fasterxml.jackson.jakarta.rs", name = "jackson-jakarta-rs-base", version = "2.15.2" }
+jackson-jacksonJrAll = { group = "com.fasterxml.jackson.jr", name = "jackson-jr-all", version = "2.15.2" }
+jackson-jacksonModuleBlackbird = { group = "com.fasterxml.jackson.module", name = "jackson-module-blackbird", version = "2.15.2" }
+jackson-jacksonModuleKotlin = { group = "com.fasterxml.jackson.module", name = "jackson-module-kotlin", version = "2.15.2" }
+jackson-jacksonModuleScala_211 = { group = "com.fasterxml.jackson.module", name = "jackson-module-scala_2.11", version = "2.15.2" }
 metrics-metricsBom = { group = "io.dropwizard.metrics", name = "metrics-bom", version.ref = "dropwizardMetrics" }
 metrics-metricsAnnotation = { group = "io.dropwizard.metrics", name = "metrics-annotation", version = "4.2.19" }
 metrics-metricsCaffeine = { group = "io.dropwizard.metrics", name = "metrics-caffeine", version = "4.2.19" }
 metrics-metricsCaffeine3 = { group = "io.dropwizard.metrics", name = "metrics-caffeine3", version = "4.2.19" }
 metrics-metricsCore = { group = "io.dropwizard.metrics", name = "metrics-core", version = "4.2.19" }
-reporter2-zipkinReporterBom = { group = "io.zipkin.reporter2", name = "zipkin-reporter-bom", version.ref = "zipkinReporter" }
-zipkin2-zipkin = { group = "io.zipkin.zipkin2", name = "zipkin", version.ref = "zipkin" }
-proto3-zipkinProto3 = { group = "io.zipkin.proto3", name = "zipkin-proto3", version.ref = "zipkinProto3" }
+reporter2-zipkinReporterBom = { group = "io.zipkin.reporter2", name = "zipkin-reporter-bom", version = "2.16.3" }
+zipkin2-zipkin = { group = "io.zipkin.zipkin2", name = "zipkin", version = "2.23.2" }
+proto3-zipkinProto3 = { group = "io.zipkin.proto3", name = "zipkin-proto3", version = "1.0.0" }
 reporter2-zipkinReporter = { group = "io.zipkin.reporter2", name = "zipkin-reporter", version = "2.16.3" }
 reporter2-zipkinReporterBrave = { group = "io.zipkin.reporter2", name = "zipkin-reporter-brave", version = "2.16.3" }
 
 
 [bundles]
 activemq = ["activemq-activemqBroker", "activemq-activemqClient", "activemq-activemqJdbcStore", "activemq-activemqSpring"]
-awsjavasdk = ["awssdk-sdkCore", "awssdk-s3", "awssdk-sqs", "awssdk-sts"]
 caffeine = ["caffeine-caffeine", "caffeine-guava", "caffeine-jcache"]
-jacksonAnnotations = ["jackson-jacksonAnnotations"]
-jacksonCore = ["jackson-jacksonCore"]
-jacksonDatabind = ["jackson-jacksonDatabind"]
-jacksonDataformat = ["jackson-jacksonDataformatAvro"]
-jacksonDatatype = ["jackson-jacksonDatatypeJdk8", "jackson-jacksonDatatypeJsr310"]
-jacksonJacksonjr = ["jackson-jacksonJrAll"]
-jacksonJakartaRs = ["jackson-jacksonJakartaRsBase"]
-jacksonJaxrs = ["jackson-jacksonJaxrsBase"]
-jacksonModule = ["jackson-jacksonModuleBlackbird"]
-jacksonModuleKotlin = ["jackson-jacksonModuleKotlin"]
-jacksonModuleScala = ["jackson-jacksonModuleScala_211"]
-zipkin = ["zipkin2-zipkin"]
-zipkinProto3 = ["proto3-zipkinProto3"]


### PR DESCRIPTION
# Description
There exists a scenario where when we resolve properties, someone may have `jackson.version` and another may have `version.jackson`. This won't pass our duplicate checks up front, but will conflict later down the road when we apply the version alias generator.

For now, we are removing version aliases from everything except for the root BOM. For any transitive BOMs, replace all properties with the resolved value even if they are unique.

We may re-add transitive properties back in at a later time, possibly by prefixing with the artifact (or something along those lines).