### PR TITLE
Cache Generated Version Catalogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,14 @@ dependencyResolutionManagement {
             // by their group or name
             excludeGroups = "some\\.group"
             excludeNames = ".*pattern"
+            // by default, we will store generated catalogs in build/version-catalogs,
+            // relative to the directory in which the settings file is stored. customize that
+            // directory by passing in a new value here. A relative directory will be resolved
+            // relative to the settings file root. An absolute directory will be used as-is.
+            // WARNING: When using a non-standard directory, be cognizant of when this file will
+            // get cleaned up (or rather, when it will _not_ . If the directory you use is not
+            // cleaned by the clean task, your catalogs will not get updated.
+            cacheDirectory = file("build/some-folder")
         }
     }
 }

--- a/plugin/config/detekt.yml
+++ b/plugin/config/detekt.yml
@@ -30,6 +30,8 @@ formatting:
     active: false
   StringTemplate:
     active: false
+  SpacingBetweenDeclarationsWithAnnotations:
+    active: false
   TrailingCommaOnCallSite:
     active: true
   TrailingCommaOnDeclarationSite:

--- a/plugin/config/detekt.yml
+++ b/plugin/config/detekt.yml
@@ -3,8 +3,8 @@ complexity:
     excludes:
       - '**/test/**'
   LongParameterList:
-    constructorThreshold: 7
-    functionThreshold: 7
+    constructorThreshold: 10
+    functionThreshold: 10
 
 exceptions:
   TooGenericExceptionThrown:

--- a/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/Generator.kt
+++ b/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/Generator.kt
@@ -129,8 +129,9 @@ object Generator {
      * @param parentModel the parent of the BOM
      * @param config [GeneratorConfig]
      * @param queue the BFS queue to add more BOMs into
-     * @param props the version properties
      * @param seenModules the set of modules we have already created libraries for
+     * @param rootDep true if this is the very first BOM in the tree, otherwise false
+     * @param container the container for the TOML file we are generating
      */
     internal fun VersionCatalogBuilder.loadBom(
         model: Model,
@@ -155,8 +156,9 @@ object Generator {
      * @param config the [GeneratorConfig]
      * @param queue the BFS queue to add more BOMs into
      * @param substitutor the [StringSubstitutor] for variable resolution
-     * @param excludedProps the set of version properties to ignore
      * @param seenModules the set of modules we have already created libraries for
+     * @param rootDep true if this is the very first BOM in the tree, otherwise false
+     * @param container the container for the TOML file we are generating
      */
     internal fun VersionCatalogBuilder.loadDependencies(
         model: Model,
@@ -245,6 +247,8 @@ object Generator {
      * @param dep the dependency
      * @param version the version of the dependency, may be a property of actual version
      * @param config the [GeneratorConfig]
+     * @param rootDep true if this is the very first BOM in the tree, otherwise false
+     * @param container the container for the TOML file we are generating
      * @return the library's alias and true if the version was a reference, or false if it was not
      */
     internal fun VersionCatalogBuilder.createLibrary(

--- a/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/Generator.kt
+++ b/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/Generator.kt
@@ -124,7 +124,7 @@ object Generator {
         cachePath: Path,
         catalogName: String,
         bom: Dependency,
-        container: TomlContainer
+        container: TomlContainer,
     ) {
         val fileName = cachedCatalogName(catalogName, bom)
         registerSaveTask(project, cachePath, fileName, container)
@@ -134,7 +134,7 @@ object Generator {
         project: Project,
         cachePath: Path,
         fileName: String,
-        container: TomlContainer
+        container: TomlContainer,
     ) {
         with(project) {
             val task =

--- a/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/Generator.kt
+++ b/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/Generator.kt
@@ -111,9 +111,15 @@ object Generator {
                 loadBom(model, parentModel, config, queue, seenModules, rootDep, container)
                 rootDep = false
             }
+
             try {
-                cachedPath.parent.createDirectories()
-                Files.write(cachedPath, container.toToml().toByteArray(Charset.defaultCharset()))
+                config.settings.gradle.buildFinished {
+                    cachedPath.parent.createDirectories()
+                    Files.write(
+                        cachedPath,
+                        container.toToml().toByteArray(Charset.defaultCharset()),
+                    )
+                }
             } catch (e: IOException) {
                 logger.warn("error creating cached library file {}", cachedPath, e)
             }

--- a/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/Generator.kt
+++ b/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/Generator.kt
@@ -95,8 +95,7 @@ object Generator {
                 else -> throw IllegalArgumentException("Unable to resolve notation ${src}")
             }
 
-        val cachedFileName = "libs.${name}-${bomDep.version}.toml"
-        val cachedPath = config.cacheDirectory.resolve(cachedFileName)
+        val cachedPath = config.cacheDirectory.resolve(cachedCatalogName(name, bomDep))
         if (cachedPath.exists()) {
             return create(name) { from(objectFactory.fileCollection().from(cachedPath)) }
         }
@@ -350,6 +349,9 @@ object Generator {
         }
         return version
     }
+
+    internal fun cachedCatalogName(name: String, dep: Dependency) =
+        "libs.${name}-${dep.artifactId}-${dep.version}.toml"
 
     /*
     Below methods inspired by / taken from

--- a/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/Generator.kt
+++ b/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/Generator.kt
@@ -6,6 +6,7 @@ import dev.aga.gradle.versioncatalogs.service.GradleDependencyResolver
 import dev.aga.gradle.versioncatalogs.tasks.SaveTask
 import java.nio.file.Path
 import java.util.function.Supplier
+import kotlin.collections.set
 import kotlin.io.path.exists
 import org.apache.commons.text.StringSubstitutor
 import org.apache.maven.model.Dependency
@@ -18,7 +19,6 @@ import org.gradle.api.initialization.resolve.MutableVersionCatalogContainer
 import org.gradle.api.internal.artifacts.DependencyResolutionServices
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.ExtensionAware
-import org.gradle.kotlin.dsl.get
 import org.gradle.kotlin.dsl.register
 import org.slf4j.LoggerFactory
 import org.tomlj.TomlContainer
@@ -143,7 +143,9 @@ object Generator {
                     destinationFile.set(project.file(fileName))
                     contents.set(container.toToml())
                 }
-            project.tasks["assemble"].finalizedBy(task)
+            // if we have an assemble task, finalize it by our task
+            // otherwise run our task right away
+            project.tasks.findByName("assemble")?.finalizedBy(task) ?: task.get().save()
         }
     }
 

--- a/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/Generator.kt
+++ b/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/Generator.kt
@@ -3,6 +3,7 @@ package dev.aga.gradle.versioncatalogs
 import dev.aga.gradle.versioncatalogs.model.Version
 import dev.aga.gradle.versioncatalogs.service.DependencyResolver
 import dev.aga.gradle.versioncatalogs.service.GradleDependencyResolver
+import java.io.IOException
 import java.nio.charset.Charset
 import java.nio.file.Files
 import java.util.function.Supplier
@@ -114,7 +115,7 @@ object Generator {
             try {
                 cachedPath.parent.createDirectories()
                 Files.write(cachedPath, container.toToml().toByteArray(Charset.defaultCharset()))
-            } catch (e: Exception) {
+            } catch (e: IOException) {
                 logger.warn("error creating cached library file {}", cachedPath, e)
             }
         }
@@ -165,7 +166,7 @@ object Generator {
         substitutor: StringSubstitutor,
         seenModules: MutableSet<String>,
         rootDep: Boolean,
-        container: TomlContainer
+        container: TomlContainer,
     ) {
         val registeredVersions = mutableSetOf<String>()
         val deps = getNewDependencies(model, seenModules, substitutor, importFilter, config)
@@ -174,7 +175,11 @@ object Generator {
                 logger.info("${model.groupId}:${model.artifactId} contains other BOMs")
                 if (rootDep) {
                     maybeRegisterVersion(
-                        version, config.versionNameGenerator, registeredVersions, container)
+                        version,
+                        config.versionNameGenerator,
+                        registeredVersions,
+                        container,
+                    )
                 }
                 createLibrary(bom, version, config, rootDep, container)
                 // if the version is a property, replace it with the
@@ -190,7 +195,11 @@ object Generator {
             (version, deps) ->
             if (rootDep) {
                 maybeRegisterVersion(
-                    version, config.versionNameGenerator, registeredVersions, container)
+                    version,
+                    config.versionNameGenerator,
+                    registeredVersions,
+                    container,
+                )
             }
             val aliases = mutableListOf<String>()
             deps.forEach { dep ->

--- a/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/Generator.kt
+++ b/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/Generator.kt
@@ -4,10 +4,9 @@ import dev.aga.gradle.versioncatalogs.model.Version
 import dev.aga.gradle.versioncatalogs.service.DependencyResolver
 import dev.aga.gradle.versioncatalogs.service.GradleDependencyResolver
 import dev.aga.gradle.versioncatalogs.tasks.SaveTask
-import java.nio.file.Path
+import java.io.File
 import java.util.function.Supplier
 import kotlin.collections.set
-import kotlin.io.path.exists
 import org.apache.commons.text.StringSubstitutor
 import org.apache.maven.model.Dependency
 import org.apache.maven.model.Model
@@ -121,7 +120,7 @@ object Generator {
 
     internal fun registerSaveTask(
         project: Project,
-        cachePath: Path,
+        cachePath: File,
         catalogName: String,
         bom: Dependency,
         container: TomlContainer,
@@ -132,14 +131,14 @@ object Generator {
 
     private fun registerSaveTask(
         project: Project,
-        cachePath: Path,
+        cachePath: File,
         fileName: String,
         container: TomlContainer,
     ) {
         with(project) {
             val task =
                 tasks.register<SaveTask>("save${fileName}") {
-                    destinationDir.set(cachePath.toFile())
+                    destinationDir.set(cachePath)
                     destinationFile.set(project.file(fileName))
                     contents.set(container.toToml())
                 }

--- a/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/GeneratorConfig.kt
+++ b/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/GeneratorConfig.kt
@@ -2,7 +2,6 @@ package dev.aga.gradle.versioncatalogs
 
 import dev.aga.gradle.versioncatalogs.service.FileCatalogParser
 import java.io.File
-import java.nio.file.Path
 import java.nio.file.Paths
 import net.pearx.kasechange.CaseFormat
 import net.pearx.kasechange.formatter.format
@@ -76,14 +75,14 @@ class GeneratorConfig(val settings: Settings) {
      * absolute path will be used exactly as provided.
      */
     @Incubating
-    var cacheDirectory: Path =
-        settings.rootDir.toPath().resolve(Paths.get("build", "version-catalogs"))
+    var cacheDirectory: File =
+        settings.rootDir.resolve(Paths.get("build", "version-catalogs").toFile())
         set(value) {
             field =
                 if (value.isAbsolute) {
                     value
                 } else {
-                    settings.rootDir.toPath().resolve(value)
+                    settings.rootDir.resolve(value)
                 }
         }
 

--- a/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/GeneratorConfig.kt
+++ b/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/GeneratorConfig.kt
@@ -66,6 +66,12 @@ class GeneratorConfig(val settings: Settings) {
      */
     var excludeNames: String? = null
 
+    /** The root directory of the project */
+    internal val rootProjectDir = settings.rootDir.toPath()
+
+    /** The directory to store our cached toml files */
+    internal val cacheDirectory = rootProjectDir.resolve(Paths.get("build", "catalogs"))
+
     internal val excludeFilter: (Dependency) -> Boolean by lazy {
         {
             val eg = excludeGroups

--- a/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/GeneratorConfig.kt
+++ b/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/GeneratorConfig.kt
@@ -69,11 +69,11 @@ class GeneratorConfig(val settings: Settings) {
     var excludeNames: String? = null
 
     /**
-     * The directory to store our cached toml file. By default, it will be stored in
-     * `build/catalogs` from the root directory of the project. When customizing the cache
-     * directory, you probably want to make sure it is cleaned up by the `clean` task. If you pass
-     * in a relative path it will be resolved from the root directory. An absolute path will be used
-     * exactly as provided.
+     * The directory to store our cached TOML file. By default, it will be stored in
+     * `build/catalogs` relative to the directory of where the settings file exists. When
+     * customizing the cache directory, you probably want to make sure it is cleaned up by the
+     * `clean` task. If you pass in a relative path it will be resolved from the root directory. An
+     * absolute path will be used exactly as provided.
      */
     @Incubating
     var cacheDirectory: Path =

--- a/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/GeneratorConfig.kt
+++ b/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/GeneratorConfig.kt
@@ -2,10 +2,12 @@ package dev.aga.gradle.versioncatalogs
 
 import dev.aga.gradle.versioncatalogs.service.FileCatalogParser
 import java.io.File
+import java.nio.file.Path
 import java.nio.file.Paths
 import net.pearx.kasechange.CaseFormat
 import net.pearx.kasechange.formatter.format
 import org.apache.maven.model.Dependency
+import org.gradle.api.Incubating
 import org.gradle.api.initialization.Settings
 
 class GeneratorConfig(val settings: Settings) {
@@ -66,11 +68,24 @@ class GeneratorConfig(val settings: Settings) {
      */
     var excludeNames: String? = null
 
-    /** The root directory of the project */
-    internal val rootProjectDir = settings.rootDir.toPath()
-
-    /** The directory to store our cached toml files */
-    internal val cacheDirectory = rootProjectDir.resolve(Paths.get("build", "catalogs"))
+    /**
+     * The directory to store our cached toml file. By default, it will be stored in
+     * `build/catalogs` from the root directory of the project. When customizing the cache
+     * directory, you probably want to make sure it is cleaned up by the `clean` task. If you pass
+     * in a relative path it will be resolved from the root directory. An absolute path will be used
+     * exactly as provided.
+     */
+    @Incubating
+    var cacheDirectory: Path =
+        settings.rootDir.toPath().resolve(Paths.get("build", "version-catalogs"))
+        set(value) {
+            field =
+                if (value.isAbsolute) {
+                    value
+                } else {
+                    settings.rootDir.toPath().resolve(value)
+                }
+        }
 
     internal val excludeFilter: (Dependency) -> Boolean by lazy {
         {

--- a/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/VersionCatalogGeneratorPlugin.kt
+++ b/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/VersionCatalogGeneratorPlugin.kt
@@ -5,6 +5,7 @@ import org.gradle.api.initialization.Settings
 import org.gradle.kotlin.dsl.create
 
 class VersionCatalogGeneratorPlugin : Plugin<Settings> {
+
     override fun apply(settings: Settings) {
         settings.extensions.create(
             "generator",

--- a/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/tasks/SaveTask.kt
+++ b/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/tasks/SaveTask.kt
@@ -1,0 +1,27 @@
+package dev.aga.gradle.versioncatalogs.tasks
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import org.slf4j.LoggerFactory
+
+abstract class SaveTask : DefaultTask() {
+    @get:Input abstract val contents: Property<String>
+    @get:OutputDirectory abstract val destinationDir: DirectoryProperty
+    @get:OutputFile abstract val destinationFile: RegularFileProperty
+
+    private val logger = LoggerFactory.getLogger(SaveTask::class.java)
+
+    @TaskAction
+    fun save() {
+        with(destinationDir.get()) {
+            asFile.mkdirs()
+            file(destinationFile.get().asFile.name).asFile.writeText(contents.get())
+        }
+    }
+}

--- a/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/tasks/SaveTask.kt
+++ b/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/tasks/SaveTask.kt
@@ -8,14 +8,11 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
-import org.slf4j.LoggerFactory
 
 abstract class SaveTask : DefaultTask() {
     @get:Input abstract val contents: Property<String>
     @get:OutputDirectory abstract val destinationDir: DirectoryProperty
     @get:OutputFile abstract val destinationFile: RegularFileProperty
-
-    private val logger = LoggerFactory.getLogger(SaveTask::class.java)
 
     @TaskAction
     fun save() {

--- a/plugin/src/main/kotlin/org/tomlj/TomlContainer.kt
+++ b/plugin/src/main/kotlin/org/tomlj/TomlContainer.kt
@@ -1,20 +1,20 @@
 package org.tomlj
 
 class TomlContainer {
-    private val zeroZero = TomlPosition.positionAt(1, 1)
+    private val oneOne = TomlPosition.positionAt(1, 1)
     private val toml: MutableTomlTable = MutableTomlTable(TomlVersion.LATEST)
     private val versions: MutableTomlTable = MutableTomlTable(TomlVersion.LATEST)
     private val libraries: MutableTomlTable = MutableTomlTable(TomlVersion.LATEST)
     private val bundles: MutableTomlTable = MutableTomlTable(TomlVersion.LATEST)
 
     init {
-        toml.set("versions", versions, zeroZero)
-        toml.set("libraries", libraries, zeroZero)
-        toml.set("bundles", bundles, zeroZero)
+        toml.set("versions", versions, oneOne)
+        toml.set("libraries", libraries, oneOne)
+        toml.set("bundles", bundles, oneOne)
     }
 
     fun addVersion(alias: String, value: String) {
-        versions.set(alias, value, zeroZero)
+        versions.set(alias, value, oneOne)
     }
 
     fun addLibrary(
@@ -25,22 +25,22 @@ class TomlContainer {
         isRef: Boolean = false,
     ) {
         val lib = MutableTomlTable(TomlVersion.LATEST)
-        lib.set("group", group, zeroZero)
-        lib.set("name", name, zeroZero)
+        lib.set("group", group, oneOne)
+        lib.set("name", name, oneOne)
         if (isRef) {
             val v = MutableTomlTable(TomlVersion.LATEST)
-            v.set("ref", version, zeroZero)
-            lib.set("version", v, zeroZero)
+            v.set("ref", version, oneOne)
+            lib.set("version", v, oneOne)
         } else {
-            lib.set("version", version, zeroZero)
+            lib.set("version", version, oneOne)
         }
-        libraries.set(alias, lib, zeroZero)
+        libraries.set(alias, lib, oneOne)
     }
 
     fun addBundle(alias: String, libraries: Iterable<String>) {
         val array = MutableTomlArray(false)
-        libraries.forEach { array.append(it, zeroZero) }
-        bundles.set(alias, array, zeroZero)
+        libraries.forEach { array.append(it, oneOne) }
+        bundles.set(alias, array, oneOne)
     }
 
     fun toToml(): String {

--- a/plugin/src/main/kotlin/org/tomlj/TomlContainer.kt
+++ b/plugin/src/main/kotlin/org/tomlj/TomlContainer.kt
@@ -22,7 +22,7 @@ class TomlContainer {
         group: String,
         name: String,
         version: String,
-        isRef: Boolean = false
+        isRef: Boolean = false,
     ) {
         val lib = MutableTomlTable(TomlVersion.LATEST)
         lib.set("group", group, zeroZero)

--- a/plugin/src/main/kotlin/org/tomlj/TomlContainer.kt
+++ b/plugin/src/main/kotlin/org/tomlj/TomlContainer.kt
@@ -22,18 +22,18 @@ class TomlContainer {
         group: String,
         name: String,
         version: String,
-        isRef: Boolean = false,
+        isRef: Boolean,
     ) {
         val lib = MutableTomlTable(TomlVersion.LATEST)
         lib.set("group", group, oneOne)
         lib.set("name", name, oneOne)
-        if (isRef) {
-            val v = MutableTomlTable(TomlVersion.LATEST)
-            v.set("ref", version, oneOne)
-            lib.set("version", v, oneOne)
-        } else {
-            lib.set("version", version, oneOne)
-        }
+        val v: Any =
+            if (isRef) {
+                MutableTomlTable(TomlVersion.LATEST).apply { set("ref", version, oneOne) }
+            } else {
+                version
+            }
+        lib.set("version", v, oneOne)
         libraries.set(alias, lib, oneOne)
     }
 

--- a/plugin/src/main/kotlin/org/tomlj/TomlContainer.kt
+++ b/plugin/src/main/kotlin/org/tomlj/TomlContainer.kt
@@ -1,0 +1,49 @@
+package org.tomlj
+
+class TomlContainer {
+    private val zeroZero = TomlPosition.positionAt(1, 1)
+    private val toml: MutableTomlTable = MutableTomlTable(TomlVersion.LATEST)
+    private val versions: MutableTomlTable = MutableTomlTable(TomlVersion.LATEST)
+    private val libraries: MutableTomlTable = MutableTomlTable(TomlVersion.LATEST)
+    private val bundles: MutableTomlTable = MutableTomlTable(TomlVersion.LATEST)
+
+    init {
+        toml.set("versions", versions, zeroZero)
+        toml.set("libraries", libraries, zeroZero)
+        toml.set("bundles", bundles, zeroZero)
+    }
+
+    fun addVersion(alias: String, value: String) {
+        versions.set(alias, value, zeroZero)
+    }
+
+    fun addLibrary(
+        alias: String,
+        group: String,
+        name: String,
+        version: String,
+        isRef: Boolean = false
+    ) {
+        val lib = MutableTomlTable(TomlVersion.LATEST)
+        lib.set("group", group, zeroZero)
+        lib.set("name", name, zeroZero)
+        if (isRef) {
+            val v = MutableTomlTable(TomlVersion.LATEST)
+            v.set("ref", version, zeroZero)
+            lib.set("version", v, zeroZero)
+        } else {
+            lib.set("version", version, zeroZero)
+        }
+        libraries.set(alias, lib, zeroZero)
+    }
+
+    fun addBundle(alias: String, libraries: Iterable<String>) {
+        val array = MutableTomlArray(false)
+        libraries.forEach { array.append(it, zeroZero) }
+        bundles.set(alias, array, zeroZero)
+    }
+
+    fun toToml(): String {
+        return toml.toToml()
+    }
+}

--- a/plugin/src/test/kotlin/dev/aga/gradle/versioncatalogs/GeneratorConfigTest.kt
+++ b/plugin/src/test/kotlin/dev/aga/gradle/versioncatalogs/GeneratorConfigTest.kt
@@ -1,13 +1,18 @@
 package dev.aga.gradle.versioncatalogs
 
 import dev.aga.gradle.versioncatalogs.GeneratorConfig.Companion.DEFAULT_ALIAS_GENERATOR
+import java.nio.file.Paths
 import net.pearx.kasechange.CaseFormat
 import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.api.initialization.Settings
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.Arguments.arguments
 import org.junit.jupiter.params.provider.MethodSource
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
 
 class GeneratorConfigTest {
     @ParameterizedTest
@@ -62,6 +67,24 @@ class GeneratorConfigTest {
     fun `case change`(source: String, from: CaseFormat, to: CaseFormat, expected: String) {
         val actual = GeneratorConfig.caseChange(source, from, to)
         Assertions.assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `cache dir`() {
+        val rootPath = Paths.get("/path", "to", "root")
+        val settings = mock<Settings> { on { rootDir } doReturn rootPath.toFile() }
+        val config = GeneratorConfig(settings)
+        var expected = rootPath.resolve(Paths.get("build", "version-catalogs"))
+        assertThat(config.cacheDirectory).isEqualTo(expected)
+
+        val absolute = Paths.get("/some/path")
+        config.cacheDirectory = absolute
+        assertThat(config.cacheDirectory).isEqualTo(absolute)
+
+        val relative = Paths.get("some/path")
+        config.cacheDirectory = relative
+        expected = rootPath.resolve(relative)
+        assertThat(config.cacheDirectory).isEqualTo(expected)
     }
 
     companion object {

--- a/plugin/src/test/kotlin/dev/aga/gradle/versioncatalogs/GeneratorConfigTest.kt
+++ b/plugin/src/test/kotlin/dev/aga/gradle/versioncatalogs/GeneratorConfigTest.kt
@@ -1,6 +1,7 @@
 package dev.aga.gradle.versioncatalogs
 
 import dev.aga.gradle.versioncatalogs.GeneratorConfig.Companion.DEFAULT_ALIAS_GENERATOR
+import java.io.File
 import java.nio.file.Paths
 import net.pearx.kasechange.CaseFormat
 import org.assertj.core.api.Assertions
@@ -74,16 +75,16 @@ class GeneratorConfigTest {
         val rootPath = Paths.get("/path", "to", "root")
         val settings = mock<Settings> { on { rootDir } doReturn rootPath.toFile() }
         val config = GeneratorConfig(settings)
-        var expected = rootPath.resolve(Paths.get("build", "version-catalogs"))
+        var expected = rootPath.resolve(Paths.get("build", "version-catalogs")).toFile()
         assertThat(config.cacheDirectory).isEqualTo(expected)
 
-        val absolute = Paths.get("/some/path")
+        val absolute = File("/some/path")
         config.cacheDirectory = absolute
         assertThat(config.cacheDirectory).isEqualTo(absolute)
 
-        val relative = Paths.get("some/path")
+        val relative = File("some/path")
         config.cacheDirectory = relative
-        expected = rootPath.resolve(relative)
+        expected = rootPath.toFile().resolve(relative)
         assertThat(config.cacheDirectory).isEqualTo(expected)
     }
 

--- a/plugin/src/test/kotlin/dev/aga/gradle/versioncatalogs/GeneratorTest.kt
+++ b/plugin/src/test/kotlin/dev/aga/gradle/versioncatalogs/GeneratorTest.kt
@@ -131,7 +131,7 @@ internal class GeneratorTest {
 
         assertTomlTableEquals(
             "myLibs",
-            "3.24.2",
+            dep,
             Paths.get("expectations", "assertj-bom", "name-exclusion-test.toml"),
         )
     }
@@ -176,7 +176,7 @@ internal class GeneratorTest {
         verify(builder, times(0)).bundle(any<String>(), any<List<String>>())
         assertTomlTableEquals(
             "myLibs",
-            "3.24.2",
+            dep,
             Paths.get("expectations", "assertj-bom", "exclusion-negative-test.toml"),
         )
     }
@@ -202,7 +202,7 @@ internal class GeneratorTest {
         verify(builder, times(0)).bundle(any<String>(), any<List<String>>())
         assertTomlTableEquals(
             "myLibs",
-            "3.24.2",
+            dep,
             Paths.get("expectations", "assertj-bom", "both-exclusion-test.toml"),
         )
     }
@@ -239,7 +239,7 @@ internal class GeneratorTest {
         val cachedLib =
             settings.rootDir
                 .toPath()
-                .resolve(Paths.get("build", "catalogs", "libs.${name}-${dep.version}.toml"))
+                .resolve(Paths.get("build", "catalogs", Generator.cachedCatalogName(name, dep)))
         assertThat(cachedLib).exists()
 
         val cachedToml = Toml.parse(cachedLib)
@@ -247,11 +247,11 @@ internal class GeneratorTest {
         assertTomlTableEquals(cachedToml, expectedToml)
     }
 
-    private fun assertTomlTableEquals(name: String, version: String, expectedPath: Path) {
+    private fun assertTomlTableEquals(name: String, dep: Dependency, expectedPath: Path) {
         val cachedLib =
             settings.rootDir
                 .toPath()
-                .resolve(Paths.get("build", "catalogs", "libs.${name}-${version}.toml"))
+                .resolve(Paths.get("build", "catalogs", Generator.cachedCatalogName(name, dep)))
         assertThat(cachedLib).exists()
 
         val cachedToml = Toml.parse(cachedLib)

--- a/plugin/src/test/kotlin/dev/aga/gradle/versioncatalogs/GeneratorTest.kt
+++ b/plugin/src/test/kotlin/dev/aga/gradle/versioncatalogs/GeneratorTest.kt
@@ -101,8 +101,7 @@ internal class GeneratorTest {
 
         assertTomlTableEquals("myLibs", dep)
         // reset the mock and regenerate the library to assert that we use the cached file instead
-        // of reprocessing
-        // the whole thing
+        // of reprocessing the whole thing
         reset(builder)
         container.generate("myLibs", objectFactory, config, resolver)
         verify(builder, times(0)).library(any<String>(), any<String>(), any<String>())

--- a/plugin/src/test/kotlin/dev/aga/gradle/versioncatalogs/GeneratorTest.kt
+++ b/plugin/src/test/kotlin/dev/aga/gradle/versioncatalogs/GeneratorTest.kt
@@ -2,6 +2,7 @@ package dev.aga.gradle.versioncatalogs
 
 import dev.aga.gradle.versioncatalogs.Generator.generate
 import dev.aga.gradle.versioncatalogs.service.MockGradleDependencyResolver
+import java.io.File
 import java.nio.file.Path
 import java.nio.file.Paths
 import org.apache.maven.model.Dependency
@@ -38,7 +39,7 @@ internal class GeneratorTest {
     private val generatedLibraries = mutableMapOf<String, LibraryAliasBuilder>()
     private val generatedBundles = mutableMapOf<String, List<String>>()
 
-    @TempDir private lateinit var projectDir: Path
+    @TempDir private lateinit var projectDir: File
     private lateinit var settings: Settings
     private lateinit var builder: VersionCatalogBuilder
     private lateinit var container: MutableVersionCatalogContainer
@@ -67,7 +68,7 @@ internal class GeneratorTest {
             }
         settings =
             mock<Settings> {
-                on { rootDir } doReturn projectDir.toFile()
+                on { rootDir } doReturn projectDir
                 on { gradle } doReturn gradle
             }
         builder =
@@ -268,7 +269,7 @@ internal class GeneratorTest {
         val cachedLib = projectDir.resolve(Generator.cachedCatalogName(name, dep))
         assertThat(cachedLib).exists()
 
-        val cachedToml = Toml.parse(cachedLib)
+        val cachedToml = Toml.parse(cachedLib.toPath())
         val expectedToml = getExpectedToml(dep)
         assertTomlTableEquals(cachedToml, expectedToml)
     }
@@ -277,7 +278,7 @@ internal class GeneratorTest {
         val cachedLib = projectDir.resolve(Generator.cachedCatalogName(name, dep))
         assertThat(cachedLib).exists()
 
-        val cachedToml = Toml.parse(cachedLib)
+        val cachedToml = Toml.parse(cachedLib.toPath())
         val expectedToml = getExpectedToml(expectedPath)
         assertTomlTableEquals(cachedToml, expectedToml)
     }
@@ -343,6 +344,5 @@ internal class GeneratorTest {
         return Triple(versions, libraries, bundles)
     }
 
-    private fun newProject(): Project =
-        ProjectBuilder.builder().withProjectDir(projectDir.toFile()).build()
+    private fun newProject(): Project = ProjectBuilder.builder().withProjectDir(projectDir).build()
 }

--- a/plugin/src/test/kotlin/dev/aga/gradle/versioncatalogs/GeneratorTest.kt
+++ b/plugin/src/test/kotlin/dev/aga/gradle/versioncatalogs/GeneratorTest.kt
@@ -8,6 +8,7 @@ import java.nio.file.Paths
 import org.apache.maven.model.Dependency
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.api.Action
+import org.gradle.api.file.FileCollection
 import org.gradle.api.initialization.Settings
 import org.gradle.api.initialization.dsl.VersionCatalogBuilder
 import org.gradle.api.initialization.dsl.VersionCatalogBuilder.LibraryAliasBuilder
@@ -22,6 +23,7 @@ import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.reset
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.tomlj.Toml
@@ -98,6 +100,13 @@ internal class GeneratorTest {
         }
 
         assertTomlTableEquals("myLibs", dep)
+        // reset the mock and regenerate the library to assert that we use the cached file instead
+        // of reprocessing
+        // the whole thing
+        reset(builder)
+        container.generate("myLibs", objectFactory, config, resolver)
+        verify(builder, times(0)).library(any<String>(), any<String>(), any<String>())
+        verify(builder).from(any<FileCollection>())
     }
 
     @Test

--- a/plugin/src/test/kotlin/dev/aga/gradle/versioncatalogs/VersionCatalogGeneratorPluginTest.kt
+++ b/plugin/src/test/kotlin/dev/aga/gradle/versioncatalogs/VersionCatalogGeneratorPluginTest.kt
@@ -1,6 +1,7 @@
 package dev.aga.gradle.versioncatalogs
 
 import java.io.File
+import java.nio.file.Paths
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.jupiter.api.BeforeEach
@@ -114,11 +115,21 @@ class VersionCatalogGeneratorPluginTest {
 
         // Run the build
         val runner =
-            GradleRunner.create().forwardOutput().withPluginClasspath().withProjectDir(projectDir)
+            GradleRunner.create()
+                .forwardOutput()
+                .withPluginClasspath()
+                .withArguments("clean", "assemble")
+                .withProjectDir(projectDir)
 
         val result = runner.build()
 
         assertThat(result.output).contains("BUILD SUCCESSFUL")
+
+        assertThat(projectDir.resolve(Paths.get("build", "version-catalogs").toString()))
+            .isDirectoryContaining { it.name == "libs.awsLibs-bom-2.21.15.toml" }
+            .isDirectoryContaining { it.name == "libs.jsonLibs-jackson-bom-2.15.2.toml" }
+            .isDirectoryContaining { it.name == "libs.junitLibs-junit-bom-5.10.0.toml" }
+            .isDirectoryContaining { it.name == "libs.mockitoLibs-mockito-bom-5.5.0.toml" }
     }
 
     @Test

--- a/plugin/src/test/resources/expectations/assertj-bom/both-exclusion-test.toml
+++ b/plugin/src/test/resources/expectations/assertj-bom/both-exclusion-test.toml
@@ -1,2 +1,6 @@
+[versions]
+
 [libraries]
 assertj-assertjGuava = { group = "org.assertj", name = "assertj-guava", version = "3.24.2" }
+
+[bundles]

--- a/plugin/src/test/resources/expectations/assertj-bom/exclusion-negative-test.toml
+++ b/plugin/src/test/resources/expectations/assertj-bom/exclusion-negative-test.toml
@@ -1,3 +1,7 @@
+[versions]
+
 [libraries]
 assertj-assertjCore = { group = "org.assertj", name = "assertj-core", version = "3.24.2" }
 assertj-assertjGuava = { group = "org.assertj", name = "assertj-guava", version = "3.24.2" }
+
+[bundles]

--- a/plugin/src/test/resources/expectations/assertj-bom/name-exclusion-test.toml
+++ b/plugin/src/test/resources/expectations/assertj-bom/name-exclusion-test.toml
@@ -1,2 +1,6 @@
+[versions]
+
 [libraries]
 assertj-assertjCore = { group = "org.assertj", name = "assertj-core", version = "3.24.2" }
+
+[bundles]


### PR DESCRIPTION
# Description
Save a copy of our generated version catalog to the build directory so that on subsequent builds, we can re-use that file instead of regenerating the library from scratch.

By default, the toml files will be saved in the folder `build/version-catalogs`, relative to the location of the settings file. If the path is overridden, that path will be used instead.

closes #15 
