### PR TITLE
Override Version Properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ dependencyResolutionManagement {
     versionCatalogs {
         generate("springLibs") { // the name of the generated catalog
             from(toml("springBootDependencies")) // name of the bom library in the version catalog
+            propertyOverrides = mapOf("jackson-bom.version" to "2.16.1") // optionally override some version properties
         }
         generate("awsLibs") { 
             from(toml("awsBom"))
@@ -117,6 +118,12 @@ dependencyResolutionManagement {
             // providing your own algorithm below. check the javadoc for more 
             // information
             versionNameGenerator = GeneratorConfig.DEFAULT_VERSION_NAME_GENERATOR
+            
+            // you can optionally override version properties from the BOM you are
+            // generating a catalog for. for example, if spring-boot-dependencies
+            // specifies jackson 2.15.3 but you want to use 2.16.1 instead, you can
+            // override the version property in their BOM
+            propertyOverrides = mapOf("jackson-bom.version" to "2.16.1")
             
             // you can optionally provide regex patterns to exclude dependencies
             // by their group or name
@@ -187,4 +194,4 @@ dependencies {
 
 - [x] Compatible with Dependabot
 - [x] Nested BOM support (i.e. `spring-boot-dependences` imports `mockito-bom`, etc)
-- [ ] Easy to override versions (similar to `ext["version.property"] = ...` in Spring Boot Dependencies plugin)
+- [x] Easy to override versions (similar to `ext["version.property"] = ...` in Spring Boot Dependencies plugin)

--- a/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/GeneratorConfig.kt
+++ b/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/GeneratorConfig.kt
@@ -86,6 +86,8 @@ class GeneratorConfig(val settings: Settings) {
                 }
         }
 
+    var propertyOverrides: Map<String, String> = emptyMap()
+
     internal val excludeFilter: (Dependency) -> Boolean by lazy {
         {
             val eg = excludeGroups

--- a/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/GeneratorConfig.kt
+++ b/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/GeneratorConfig.kt
@@ -86,6 +86,15 @@ class GeneratorConfig(val settings: Settings) {
                 }
         }
 
+    /**
+     * Override property values that are set in the root BOM you are generating a catalog for. For
+     * example if the BOM has the property `jackson-bom.version` with the value `2.15.3` but you'd
+     * rather use `2.16.1`, you can pass in values to override the BOM.
+     *
+     * ```kotlin
+     * propertyOverrides = mapOf("jackson-bom" to "2.16.1")
+     * ```
+     */
     var propertyOverrides: Map<String, String> = emptyMap()
 
     internal val excludeFilter: (Dependency) -> Boolean by lazy {

--- a/plugin/src/test/kotlin/dev/aga/gradle/versioncatalogs/GeneratorTest.kt
+++ b/plugin/src/test/kotlin/dev/aga/gradle/versioncatalogs/GeneratorTest.kt
@@ -18,8 +18,11 @@ import org.gradle.api.invocation.Gradle
 import org.gradle.api.model.ObjectFactory
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.Arguments.arguments
+import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
@@ -98,19 +101,18 @@ internal class GeneratorTest {
             }
     }
 
-    @Test
-    fun testGenerate() {
-        val dep = dep("org.springframework.boot", "spring-boot-dependencies", "3.1.2")
-        val resolver = MockGradleDependencyResolver(resourceRoot.resolve("poms"))
+    @ParameterizedTest
+    @MethodSource("testGenerateProvider")
+    fun testGenerate(dep: Dependency, cfg: GeneratorConfig.() -> Unit, expectedCatalog: Path) {
         val config =
-            GeneratorConfig(settings).apply {
+            GeneratorConfig(settings).apply(cfg).apply {
                 source = { dep }
                 cacheDirectory = projectDir
             }
-
+        val resolver = MockGradleDependencyResolver(resourceRoot.resolve("poms"))
         container.generate("myLibs", objectFactory, config, resolver)
         verify(container).create(eq("myLibs"), any<Action<VersionCatalogBuilder>>())
-        val (versions, libraries, bundles) = getExpectedCatalog(dep)
+        val (versions, libraries, bundles) = getExpectedCatalog(expectedCatalog)
         // validate the versions
         verify(builder, times(versions.size())).version(any<String>(), any<String>())
         versions.dottedKeySet().forEach { v -> verify(builder).version(v, versions.getString(v)!!) }
@@ -126,163 +128,13 @@ internal class GeneratorTest {
             assertThat(expectedLibraries).containsExactlyInAnyOrderElementsOf(generatedBundles[it])
         }
 
-        assertTomlTableEquals("myLibs", dep)
+        assertTomlTableEquals("myLibs", dep, expectedCatalog)
         // reset the mock and regenerate the library to assert that we use the cached file instead
         // of reprocessing the whole thing
         reset(builder)
         container.generate("myLibs", objectFactory, config, resolver)
         verify(builder, times(0)).library(any<String>(), any<String>(), any<String>())
         verify(builder).from(any<FileCollection>())
-    }
-
-    @Test
-    fun testGenerate_ExcludeByName() {
-        val dep = dep("org.assertj", "assertj-bom", "3.24.2")
-        val resolver = MockGradleDependencyResolver(resourceRoot.resolve("poms"))
-        val config =
-            GeneratorConfig(settings).apply {
-                source = { dep }
-                excludeNames = "^assertj-guava$"
-                cacheDirectory = projectDir
-            }
-
-        container.generate("myLibs", objectFactory, config, resolver)
-        verify(container).create(eq("myLibs"), any<Action<VersionCatalogBuilder>>())
-        val (_, libraries, _) =
-            getExpectedCatalog(Paths.get("expectations", "assertj-bom", "name-exclusion-test.toml"))
-
-        verify(builder, times(0)).version(any<String>(), any<String>())
-        verify(builder, times(1)).library(any<String>(), any<String>(), any<String>())
-        verifyLibraries(libraries)
-        verify(builder, times(0)).bundle(any<String>(), any<List<String>>())
-
-        assertTomlTableEquals(
-            "myLibs",
-            dep,
-            Paths.get("expectations", "assertj-bom", "name-exclusion-test.toml"),
-        )
-    }
-
-    @Test
-    fun testGenerate_ExcludeByGroup() {
-        val dep = dep("org.assertj", "assertj-bom", "3.24.2")
-        val resolver = MockGradleDependencyResolver(resourceRoot.resolve("poms"))
-        val config =
-            GeneratorConfig(settings).apply {
-                source = { dep }
-                excludeGroups = "org\\.assertj"
-                cacheDirectory = projectDir
-            }
-
-        container.generate("myLibs", objectFactory, config, resolver)
-        verify(container).create(eq("myLibs"), any<Action<VersionCatalogBuilder>>())
-        verify(builder, times(0)).version(any<String>(), any<String>())
-        verify(builder, times(0)).library(any<String>(), any<String>(), any<String>())
-        verify(builder, times(0)).bundle(any<String>(), any<List<String>>())
-    }
-
-    @Test
-    fun testGenerate_ExcludeByBoth_Negative() {
-        val dep = dep("org.assertj", "assertj-bom", "3.24.2")
-        val resolver = MockGradleDependencyResolver(resourceRoot.resolve("poms"))
-        val config =
-            GeneratorConfig(settings).apply {
-                source = { dep }
-                excludeGroups = "org\\.assertj"
-                excludeNames = "xyz"
-                cacheDirectory = projectDir
-            }
-
-        container.generate("myLibs", objectFactory, config, resolver)
-        verify(container).create(eq("myLibs"), any<Action<VersionCatalogBuilder>>())
-        val (_, libraries, _) =
-            getExpectedCatalog(
-                Paths.get("expectations", "assertj-bom", "exclusion-negative-test.toml"),
-            )
-        verify(builder, times(0)).version(any<String>(), any<String>())
-        verify(builder, times(2)).library(any<String>(), any<String>(), any<String>())
-        verifyLibraries(libraries)
-        verify(builder, times(0)).bundle(any<String>(), any<List<String>>())
-        assertTomlTableEquals(
-            "myLibs",
-            dep,
-            Paths.get("expectations", "assertj-bom", "exclusion-negative-test.toml"),
-        )
-    }
-
-    @Test
-    fun testGenerate_ExcludeByBoth_Positive() {
-        val dep = dep("org.assertj", "assertj-bom", "3.24.2")
-        val resolver = MockGradleDependencyResolver(resourceRoot.resolve("poms"))
-        val config =
-            GeneratorConfig(settings).apply {
-                source = { dep }
-                excludeGroups = "org\\.assertj"
-                excludeNames = "assertj-core"
-                cacheDirectory = projectDir
-            }
-
-        container.generate("myLibs", objectFactory, config, resolver)
-        verify(container).create(eq("myLibs"), any<Action<VersionCatalogBuilder>>())
-        val (_, libraries, _) =
-            getExpectedCatalog(Paths.get("expectations", "assertj-bom", "both-exclusion-test.toml"))
-        verify(builder, times(0)).version(any<String>(), any<String>())
-        verify(builder, times(1)).library(any<String>(), any<String>(), any<String>())
-        verifyLibraries(libraries)
-        verify(builder, times(0)).bundle(any<String>(), any<List<String>>())
-        assertTomlTableEquals(
-            "myLibs",
-            dep,
-            Paths.get("expectations", "assertj-bom", "both-exclusion-test.toml"),
-        )
-    }
-
-    @Test
-    fun testGenerate_PropertyOverrides() {
-        val dep = dep("org.springframework.boot", "spring-boot-dependencies", "3.1.2")
-        val resolver = MockGradleDependencyResolver(resourceRoot.resolve("poms"))
-        val config =
-            GeneratorConfig(settings).apply {
-                source = { dep }
-                cacheDirectory = projectDir
-                propertyOverrides =
-                    mapOf(
-                        "assertj.version" to "3.25.3",
-                        "caffeine.version" to "3.1.8",
-                        "jackson-bom.version" to "2.16.1",
-                    )
-            }
-
-        container.generate("myLibs", objectFactory, config, resolver)
-        verify(container).create(eq("myLibs"), any<Action<VersionCatalogBuilder>>())
-        val (versions, libraries, bundles) =
-            getExpectedCatalog(
-                Paths.get(
-                    "expectations",
-                    "spring-boot-dependencies",
-                    "property-overrides.toml",
-                ),
-            )
-        // validate the versions
-        verify(builder, times(versions.size())).version(any<String>(), any<String>())
-        versions.dottedKeySet().forEach { v -> verify(builder).version(v, versions.getString(v)!!) }
-
-        verify(builder, times(libraries.size()))
-            .library(any<String>(), any<String>(), any<String>())
-        verifyLibraries(libraries)
-
-        verify(builder, times(bundles.size())).bundle(any<String>(), any<List<String>>())
-        bundles.dottedKeySet().forEach {
-            assertThat(generatedBundles).containsKey(it)
-            val expectedLibraries = bundles.getArrayOrEmpty(it).toList()
-            assertThat(expectedLibraries).containsExactlyInAnyOrderElementsOf(generatedBundles[it])
-        }
-
-        assertTomlTableEquals(
-            "myLibs",
-            dep,
-            Paths.get("expectations", "spring-boot-dependencies", "property-overrides.toml"),
-        )
     }
 
     private fun verifyLibraries(libraries: TomlTable) {
@@ -311,15 +163,6 @@ internal class GeneratorTest {
         for (i in 0 until actual.size()) {
             assertThat(actual[i]).isEqualTo(expected[i])
         }
-    }
-
-    private fun assertTomlTableEquals(name: String, dep: Dependency) {
-        val cachedLib = projectDir.resolve(Generator.cachedCatalogName(name, dep))
-        assertThat(cachedLib).exists()
-
-        val cachedToml = Toml.parse(cachedLib.toPath())
-        val expectedToml = getExpectedToml(dep)
-        assertTomlTableEquals(cachedToml, expectedToml)
     }
 
     private fun assertTomlTableEquals(name: String, dep: Dependency, expectedPath: Path) {
@@ -358,30 +201,8 @@ internal class GeneratorTest {
         return result.joinToString(".")
     }
 
-    private fun dep(groupId: String, artifactId: String, version: String): Dependency {
-        return Dependency().apply {
-            this.groupId = groupId
-            this.artifactId = artifactId
-            this.version = version
-            type = "pom"
-        }
-    }
-
-    private fun getExpectedToml(dep: Dependency): TomlParseResult {
-        val path = Paths.get("expectations", "${dep.artifactId}", "libs.versions.toml")
-        return Toml.parse(resourceRoot.resolve(path))
-    }
-
     private fun getExpectedToml(tomlPath: Path): TomlParseResult {
         return Toml.parse(resourceRoot.resolve(tomlPath))
-    }
-
-    private fun getExpectedCatalog(dep: Dependency): Triple<TomlTable, TomlTable, TomlTable> {
-        val parseResult = getExpectedToml(dep)
-        val versions = parseResult.getTableOrEmpty("versions")
-        val libraries = parseResult.getTableOrEmpty("libraries")
-        val bundles = parseResult.getTableOrEmpty("bundles")
-        return Triple(versions, libraries, bundles)
     }
 
     private fun getExpectedCatalog(tomlPath: Path): Triple<TomlTable, TomlTable, TomlTable> {
@@ -393,4 +214,77 @@ internal class GeneratorTest {
     }
 
     private fun newProject(): Project = ProjectBuilder.builder().withProjectDir(projectDir).build()
+
+    companion object {
+        @JvmStatic
+        fun testGenerateProvider(): List<Arguments> {
+            val sb312 = dep("org.springframework.boot", "spring-boot-dependencies", "3.1.2")
+            val assertj3242 = dep("org.assertj", "assertj-bom", "3.24.2")
+
+            return listOf(
+                createArgs(
+                    sb312,
+                    "libs.versions.toml",
+                ) {},
+                createArgs(
+                    assertj3242,
+                    "name-exclusion-test.toml",
+                ) {
+                    excludeNames = "^assertj-guava$"
+                },
+                createArgs(
+                    assertj3242,
+                    "empty.toml",
+                ) {
+                    excludeGroups = "org\\.assertj"
+                },
+                createArgs(
+                    assertj3242,
+                    "exclusion-negative-test.toml",
+                ) {
+                    excludeGroups = "org\\.assertj"
+                    excludeNames = "xyz"
+                },
+                createArgs(
+                    assertj3242,
+                    "both-exclusion-test.toml",
+                ) {
+                    excludeGroups = "org\\.assertj"
+                    excludeNames = "assertj-core"
+                },
+                createArgs(
+                    sb312,
+                    "property-overrides.toml",
+                ) {
+                    propertyOverrides =
+                        mapOf(
+                            "assertj.version" to "3.25.3",
+                            "caffeine.version" to "3.1.8",
+                            "jackson-bom.version" to "2.16.1",
+                        )
+                },
+            )
+        }
+
+        private fun createArgs(
+            dep: Dependency,
+            expectedFileName: String,
+            conf: GeneratorConfig.() -> Unit,
+        ): Arguments {
+            return arguments(dep, conf, expectedPath(dep, expectedFileName))
+        }
+
+        private fun expectedPath(dep: Dependency, fileName: String): Path {
+            return Paths.get("expectations", dep.artifactId, fileName)
+        }
+
+        private fun dep(groupId: String, artifactId: String, version: String): Dependency {
+            return Dependency().apply {
+                this.groupId = groupId
+                this.artifactId = artifactId
+                this.version = version
+                type = "pom"
+            }
+        }
+    }
 }

--- a/plugin/src/test/resources/expectations/assertj-bom/empty.toml
+++ b/plugin/src/test/resources/expectations/assertj-bom/empty.toml
@@ -1,0 +1,5 @@
+[versions]
+
+[libraries]
+
+[bundles]

--- a/plugin/src/test/resources/expectations/spring-boot-dependencies/property-overrides.toml
+++ b/plugin/src/test/resources/expectations/spring-boot-dependencies/property-overrides.toml
@@ -1,0 +1,62 @@
+[versions]
+activemq = "5.18.2"
+assertj = "3.25.3"
+brave = "5.15.1"
+caffeine = "3.1.8"
+dropwizardMetrics = "4.2.19"
+jacksonBom = "2.16.1"
+
+[libraries]
+activemq-activemqBroker = { group = "org.apache.activemq", name = "activemq-broker", version.ref = "activemq" }
+activemq-activemqClient = { group = "org.apache.activemq", name = "activemq-client", version.ref = "activemq" }
+activemq-activemqJdbcStore = { group = "org.apache.activemq", name = "activemq-jdbc-store", version.ref = "activemq" }
+activemq-activemqSpring = { group = "org.apache.activemq", name = "activemq-spring", version.ref = "activemq" }
+assertj-assertjBom = { group = "org.assertj", name = "assertj-bom", version.ref = "assertj" }
+assertj-assertjCore = { group = "org.assertj", name = "assertj-core", version = "3.25.3" }
+assertj-assertjGuava = { group = "org.assertj", name = "assertj-guava", version = "3.25.3" }
+awssdk-bom = { group = "software.amazon.awssdk", name = "bom", version = "2.21.21" }
+awssdk-sdkCore = { group = "software.amazon.awssdk", name = "sdk-core", version = "2.21.21" }
+awssdk-s3 = { group = "software.amazon.awssdk", name = "s3", version = "2.21.21" }
+awssdk-sqs = { group = "software.amazon.awssdk", name = "sqs", version = "2.21.21" }
+awssdk-sts = { group = "software.amazon.awssdk", name = "sts", version = "2.21.21" }
+spring-springBoot = { group = "org.springframework.boot", name = "spring-boot", version = "3.1.2" }
+spring-springBootDevtools = { group = "org.springframework.boot", name = "spring-boot-devtools", version = "3.1.2" }
+spring-springBootStarterActuator = { group = "org.springframework.boot", name = "spring-boot-starter-actuator", version = "3.1.2" }
+spring-springBootStarterAop = { group = "org.springframework.boot", name = "spring-boot-starter-aop", version = "3.1.2" }
+spring-springBootStarterJdbc = { group = "org.springframework.boot", name = "spring-boot-starter-jdbc", version = "3.1.2" }
+spring-springBootStarterWeb = { group = "org.springframework.boot", name = "spring-boot-starter-web", version = "3.1.2" }
+brave-braveBom = { group = "io.zipkin.brave", name = "brave-bom", version.ref = "brave" }
+brave-brave = { group = "io.zipkin.brave", name = "brave", version = "5.15.1" }
+brave-braveTests = { group = "io.zipkin.brave", name = "brave-tests", version = "5.15.1" }
+brave-braveSpringBeans = { group = "io.zipkin.brave", name = "brave-spring-beans", version = "5.15.1" }
+caffeine-caffeine = { group = "com.github.ben-manes.caffeine", name = "caffeine", version.ref = "caffeine" }
+caffeine-guava = { group = "com.github.ben-manes.caffeine", name = "guava", version.ref = "caffeine" }
+caffeine-jcache = { group = "com.github.ben-manes.caffeine", name = "jcache", version.ref = "caffeine" }
+jackson-jacksonBom = { group = "com.fasterxml.jackson", name = "jackson-bom", version.ref = "jacksonBom" }
+jackson-jacksonAnnotations = { group = "com.fasterxml.jackson.core", name = "jackson-annotations", version = "2.16.1" }
+jackson-jacksonCore = { group = "com.fasterxml.jackson.core", name = "jackson-core", version = "2.16.1" }
+jackson-jacksonDatabind = { group = "com.fasterxml.jackson.core", name = "jackson-databind", version = "2.16.1" }
+jackson-jacksonDataformatAvro = { group = "com.fasterxml.jackson.dataformat", name = "jackson-dataformat-avro", version = "2.16.1" }
+jackson-jacksonDatatypeJdk8 = { group = "com.fasterxml.jackson.datatype", name = "jackson-datatype-jdk8", version = "2.16.1" }
+jackson-jacksonDatatypeJsr310 = { group = "com.fasterxml.jackson.datatype", name = "jackson-datatype-jsr310", version = "2.16.1" }
+jackson-jacksonJaxrsBase = { group = "com.fasterxml.jackson.jaxrs", name = "jackson-jaxrs-base", version = "2.16.1" }
+jackson-jacksonJakartaRsBase = { group = "com.fasterxml.jackson.jakarta.rs", name = "jackson-jakarta-rs-base", version = "2.16.1" }
+jackson-jacksonJrAll = { group = "com.fasterxml.jackson.jr", name = "jackson-jr-all", version = "2.16.1" }
+jackson-jacksonModuleBlackbird = { group = "com.fasterxml.jackson.module", name = "jackson-module-blackbird", version = "2.16.1" }
+jackson-jacksonModuleKotlin = { group = "com.fasterxml.jackson.module", name = "jackson-module-kotlin", version = "2.16.1" }
+jackson-jacksonModuleScala_211 = { group = "com.fasterxml.jackson.module", name = "jackson-module-scala_2.11", version = "2.16.1" }
+metrics-metricsBom = { group = "io.dropwizard.metrics", name = "metrics-bom", version.ref = "dropwizardMetrics" }
+metrics-metricsAnnotation = { group = "io.dropwizard.metrics", name = "metrics-annotation", version = "4.2.19" }
+metrics-metricsCaffeine = { group = "io.dropwizard.metrics", name = "metrics-caffeine", version = "4.2.19" }
+metrics-metricsCaffeine3 = { group = "io.dropwizard.metrics", name = "metrics-caffeine3", version = "4.2.19" }
+metrics-metricsCore = { group = "io.dropwizard.metrics", name = "metrics-core", version = "4.2.19" }
+reporter2-zipkinReporterBom = { group = "io.zipkin.reporter2", name = "zipkin-reporter-bom", version = "2.16.3" }
+zipkin2-zipkin = { group = "io.zipkin.zipkin2", name = "zipkin", version = "2.23.2" }
+proto3-zipkinProto3 = { group = "io.zipkin.proto3", name = "zipkin-proto3", version = "1.0.0" }
+reporter2-zipkinReporter = { group = "io.zipkin.reporter2", name = "zipkin-reporter", version = "2.16.3" }
+reporter2-zipkinReporterBrave = { group = "io.zipkin.reporter2", name = "zipkin-reporter-brave", version = "2.16.3" }
+
+
+[bundles]
+activemq = ["activemq-activemqBroker", "activemq-activemqClient", "activemq-activemqJdbcStore", "activemq-activemqSpring"]
+caffeine = ["caffeine-caffeine", "caffeine-guava", "caffeine-jcache"]

--- a/plugin/src/test/resources/poms/assertj-bom-3.25.3.pom
+++ b/plugin/src/test/resources/poms/assertj-bom-3.25.3.pom
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.assertj</groupId>
+  <artifactId>assertj-bom</artifactId>
+  <version>3.25.3</version>
+  <packaging>pom</packaging>
+  <name>AssertJ (Bill of Materials)</name>
+  <description>This Bill of Materials POM can be used to ease dependency management when referencing multiple AssertJ artifacts using Gradle or Maven.</description>
+  <url>https://assertj.github.io/doc/</url>
+  <inceptionYear>2012</inceptionYear>
+  <organization>
+    <name>AssertJ</name>
+    <url>https://assertj.github.io/doc/</url>
+  </organization>
+  <licenses>
+    <license>
+      <name>Apache License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+  <developers>
+    <developer>
+      <id>joel-costigliola</id>
+      <name>Joel Costigliola</name>
+      <email>joel.costigliola at gmail.com</email>
+      <roles>
+        <role>Owner</role>
+        <role>Developer</role>
+      </roles>
+    </developer>
+    <developer>
+      <id>scordio</id>
+      <name>Stefano Cordio</name>
+      <roles>
+        <role>Developer</role>
+      </roles>
+    </developer>
+    <developer>
+      <id>PascalSchumacher</id>
+      <name>Pascal Schumacher</name>
+      <roles>
+        <role>Developer</role>
+      </roles>
+    </developer>
+    <developer>
+      <id>epeee</id>
+      <name>Erhard Pointl</name>
+      <roles>
+        <role>Developer</role>
+      </roles>
+    </developer>
+    <developer>
+      <id>croesch</id>
+      <name>Christian Rösch</name>
+      <roles>
+        <role>Developer</role>
+      </roles>
+    </developer>
+    <developer>
+      <id>VanRoy</id>
+      <name>Julien Roy</name>
+      <roles>
+        <role>Developer</role>
+      </roles>
+    </developer>
+    <developer>
+      <id>regis1512</id>
+      <name>Régis Pouiller</name>
+      <roles>
+        <role>Developer</role>
+      </roles>
+    </developer>
+    <developer>
+      <id>fbiville</id>
+      <name>Florent Biville</name>
+      <roles>
+        <role>Developer</role>
+      </roles>
+    </developer>
+    <developer>
+      <id>Patouche</id>
+      <name>Patrick Allain</name>
+      <roles>
+        <role>Developer</role>
+      </roles>
+    </developer>
+  </developers>
+  <scm>
+    <connection>scm:git:https://github.com/assertj/assertj.git/assertj-bom</connection>
+    <developerConnection>scm:git:https://github.com/assertj/assertj.git/assertj-bom</developerConnection>
+    <tag>assertj-build-3.25.3</tag>
+    <url>https://github.com/assertj/assertj/assertj-bom</url>
+  </scm>
+  <issueManagement>
+    <system>GitHub</system>
+    <url>https://github.com/assertj/assertj/issues</url>
+  </issueManagement>
+  <distributionManagement>
+    <repository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+  </distributionManagement>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-core</artifactId>
+        <version>3.25.3</version>
+      </dependency>
+      <dependency>
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-guava</artifactId>
+        <version>3.25.3</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>

--- a/plugin/src/test/resources/poms/jackson-bom-2.16.1.pom
+++ b/plugin/src/test/resources/poms/jackson-bom-2.16.1.pom
@@ -1,0 +1,175 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.fasterxml.jackson</groupId>
+    <artifactId>jackson-parent</artifactId>
+    <!-- note: does NOT change for every version of bom -->
+    <version>2.16</version>
+  </parent>
+
+  <artifactId>jackson-bom</artifactId>
+  <name>Jackson BOM</name>
+  <description>Bill of Materials pom for getting full, complete set of compatible versions
+of Jackson components maintained by FasterXML.com
+  </description>
+  <version>2.16.1</version>
+  <packaging>pom</packaging>
+
+  <modules>
+   <module>base</module> <!-- "It's all about that base 'bout that base..." -->
+  </modules>
+
+  <organization>
+    <name>FasterXML</name>
+    <url>http://fasterxml.com/</url>
+  </organization>
+  <licenses>
+    <license>
+      <name>Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+  <developers>
+    <developer>
+      <id>cowtowncoder</id>
+      <name>Tatu Saloranta</name>
+      <email>tatu@fasterxml.com</email>
+    </developer>
+  </developers>
+
+  <url>https://github.com/FasterXML/jackson-bom</url>
+  <scm>
+    <connection>scm:git:git@github.com:FasterXML/jackson-bom.git</connection>
+    <developerConnection>scm:git:git@github.com:FasterXML/jackson-bom.git</developerConnection>
+    <url>https://github.com/FasterXML/jackson-bom</url>
+    <tag>jackson-bom-2.16.1</tag>
+  </scm>
+
+  <properties>
+    <jackson.version>2.16.1</jackson.version>
+
+    <!-- 25-Sep-2019, tatu: With Jackson 2.x we will release full patch-level versions
+           of annotations BUT they are all identical, content-wise.
+           Given this, annotations could EITHER be `2.11.0` OR `${jackson.version}`.
+           Based on dev feedback, with 2.10 we will do latter. It apparently is less
+           confusing than alternative.
+      -->
+    <jackson.version.annotations>${jackson.version}</jackson.version.annotations>
+    <jackson.version.core>${jackson.version}</jackson.version.core>
+    <jackson.version.databind>${jackson.version}</jackson.version.databind>
+    <jackson.version.dataformat>${jackson.version}</jackson.version.dataformat>
+    <jackson.version.datatype>${jackson.version}</jackson.version.datatype>
+    <jackson.version.jaxrs>${jackson.version}</jackson.version.jaxrs>
+    <jackson.version.jakarta.rs>${jackson.version}</jackson.version.jakarta.rs>
+    <jackson.version.jacksonjr>${jackson.version}</jackson.version.jacksonjr>
+
+    <jackson.version.module>${jackson.version}</jackson.version.module>
+    <jackson.version.module.kotlin>${jackson.version.module}</jackson.version.module.kotlin>
+    <jackson.version.module.scala>${jackson.version.module}</jackson.version.module.scala>
+    <!-- JPMS Library Updates-->
+    <javax.activation.version>1.2.0</javax.activation.version>
+
+    <!-- for Reproducible Builds -->
+    <project.build.outputTimestamp>2023-12-24T03:55:12Z</project.build.outputTimestamp>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+
+      <!-- Core -->
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-annotations</artifactId>
+        <version>${jackson.version.annotations}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-core</artifactId>
+        <version>${jackson.version.core}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>${jackson.version.databind}</version>
+      </dependency>
+
+      <!-- Data Formats -->
+      <dependency>
+        <groupId>com.fasterxml.jackson.dataformat</groupId>
+        <artifactId>jackson-dataformat-avro</artifactId>
+        <version>${jackson.version.dataformat}</version>
+      </dependency>
+
+      <!-- Data Types -->
+
+      <dependency>
+        <groupId>com.fasterxml.jackson.datatype</groupId>
+        <artifactId>jackson-datatype-jdk8</artifactId>
+        <version>${jackson.version.datatype}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.datatype</groupId>
+        <artifactId>jackson-datatype-jsr310</artifactId>
+        <version>${jackson.version.datatype}</version>
+      </dependency>
+
+      <!-- JAX-RS -->
+      <dependency>
+        <groupId>com.fasterxml.jackson.jaxrs</groupId>
+        <artifactId>jackson-jaxrs-base</artifactId>
+        <version>${jackson.version.jaxrs}</version>
+      </dependency>
+
+      <!-- Jakarta-RS (2.13+) -->
+      <dependency>
+        <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
+        <artifactId>jackson-jakarta-rs-base</artifactId>
+        <version>${jackson.version.jakarta.rs}</version>
+      </dependency>
+
+      <!-- Jackson Jr. -->
+      <dependency>
+        <groupId>com.fasterxml.jackson.jr</groupId>
+        <artifactId>jackson-jr-all</artifactId>
+        <version>${jackson.version.jacksonjr}</version>
+      </dependency>
+
+      <!-- Modules, basic -->
+      <dependency>
+        <groupId>com.fasterxml.jackson.module</groupId>
+        <artifactId>jackson-module-blackbird</artifactId>
+        <version>${jackson.version.module}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.module</groupId>
+        <artifactId>jackson-module-kotlin</artifactId>
+        <version>${jackson.version.module.kotlin}</version>
+      </dependency>
+
+      <!-- Language Modules -->
+
+      <!-- 21-Nov-2020, tatu: Scala 2.10 support dropped in Jackson 2.12 -->
+      <dependency>
+        <groupId>com.fasterxml.jackson.module</groupId>
+        <artifactId>jackson-module-scala_2.11</artifactId>
+        <version>${jackson.version.module.scala}</version>
+      </dependency>
+
+    </dependencies>
+  </dependencyManagement>
+
+  <!-- Alas, need to include snapshot reference since otherwise can not find
+       snapshot of parent... -->
+  <repositories>
+    <repository>
+      <id>sonatype-nexus-snapshots</id>
+      <name>Sonatype Nexus Snapshots</name>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <releases><enabled>false</enabled></releases>
+      <snapshots><enabled>true</enabled></snapshots>
+    </repository>
+  </repositories>
+</project>

--- a/plugin/src/test/resources/poms/jackson-parent-2.16.pom
+++ b/plugin/src/test/resources/poms/jackson-parent-2.16.pom
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+   <groupId>com.fasterxml</groupId>
+    <artifactId>oss-parent</artifactId>
+    <version>56</version>
+  </parent>
+
+  <groupId>com.fasterxml.jackson</groupId>
+  <artifactId>jackson-parent</artifactId>
+  <version>2.16</version>
+  <packaging>pom</packaging>
+
+  <name>Jackson parent poms</name>
+  <description>Parent pom for all Jackson components</description>
+  <url>http://github.com/FasterXML/</url>
+  <organization>
+    <name>FasterXML</name>
+    <url>http://fasterxml.com/</url>
+  </organization>
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <id>cowtowncoder</id>
+      <name>Tatu Saloranta</name>
+      <email>tatu@fasterxml.com</email>
+    </developer>
+  </developers>
+
+  <scm>
+    <connection>scm:git:git@github.com:FasterXML/jackson-parent.git</connection>
+    <developerConnection>scm:git:git@github.com:FasterXML/jackson-parent.git</developerConnection>
+    <url>http://github.com/FasterXML/jackson-parent</url>
+    <tag>jackson-parent-2.16</tag>
+  </scm>
+
+  <properties>
+    <!-- 02-Oct-2015, tatu: Jackson 2.4 and above are Java 6 (earlier versions Java 5);
+          Jackson 2.7 and above Java 7 (with exception of `jackson-core`/`jackson-annotations` still Java 6),
+    -->
+    <!-- 09-Jan-2021, tatu: Jackson 2.13 finally raises baseline to Java 8, with continuing
+       exception fo `jackson-core`/`jackson-annotations` as Java 6 -->
+    <javac.src.version>1.8</javac.src.version>
+    <javac.target.version>1.8</javac.target.version>
+    <maven.compiler.source>${javac.src.version}</maven.compiler.source>
+    <maven.compiler.target>${javac.target.version}</maven.compiler.target>
+    
+    <javac.debuglevel>lines,source,vars</javac.debuglevel>
+
+    <!--
+     | For automatically generating PackageVersion.java. Your child pom.xml must define
+     | packageVersion.dir and packageVersion.package, and must set the phase of the
+     | process-packageVersion execution of maven-replacer-plugin to 'generate-sources'.
+    -->
+    <packageVersion.template.input>${basedir}/src/main/java/${packageVersion.dir}/PackageVersion.java.in</packageVersion.template.input>
+    <packageVersion.template.output>${generatedSourcesDir}/${packageVersion.dir}/PackageVersion.java</packageVersion.template.output>
+
+    <project.build.outputTimestamp>2023-11-15T19:21:06Z</project.build.outputTimestamp>
+  </properties>
+
+  <!-- 17-Sep-2021, tatu: Used to have junit prior to Jackson 2.13, removed due to
+      [jackson-bom#43] issue
+    -->
+
+  <!-- Alas, need to include snapshot reference since otherwise can not find
+       snapshot of parent... -->
+  <repositories>
+    <repository>
+      <id>sonatype-nexus-snapshots</id>
+      <name>Sonatype Nexus Snapshots</name>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <releases><enabled>false</enabled></releases>
+      <snapshots><enabled>true</enabled></snapshots>
+    </repository>
+  </repositories>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+
+        <!-- Jackson has stricter enforced requirements than parent pom -->
+        <plugin>
+         <groupId>org.apache.maven.plugins</groupId>
+         <artifactId>maven-enforcer-plugin</artifactId>
+         <executions>
+          <execution>
+            <id>enforce-java</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                 <requireMavenVersion>
+                  <version>[3.6,)</version>
+                  <message>[ERROR] The currently supported version of Maven is 3.6 or higher</message>
+                </requireMavenVersion>
+                <requirePluginVersions>
+                  <banLatest>true</banLatest>
+                  <banRelease>true</banRelease>
+                  <banSnapshots>true</banSnapshots>
+                  <phases>clean,deploy,site</phases>
+                  <message>[ERROR] Best Practice is to always define plugin versions!</message>
+                </requirePluginVersions>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+        </plugin>
+        <!-- use of replacer plug-in specific to Jackson -->
+        <plugin>
+          <groupId>com.google.code.maven-replacer-plugin</groupId>
+          <artifactId>replacer</artifactId>
+          <version>${version.plugin.replacer}</version>
+          <executions>
+            <execution>
+              <id>process-packageVersion</id>
+              <goals>
+                <goal>replace</goal>
+              </goals>
+              <!--
+               | We explicitly omit 'phase' here so child poms can opt in to
+               | generating their PackageVersion.java file.
+               |
+               | If your child pom wants a PackageVersion.java file, define
+               | the 'packageVersion.dir' and 'packageVersion.package' properties
+               | and include the commented-out section in your child pom's plugin
+               | for this execution ID.
+               <phase>generate-sources</phase>
+              -->
+            </execution>
+          </executions>
+          <configuration>
+            <file>${packageVersion.template.input}</file>
+            <outputFile>${packageVersion.template.output}</outputFile>
+            <replacements>
+              <replacement>
+                <token>@package@</token>
+                <value>${packageVersion.package}</value>
+              </replacement>
+              <replacement>
+                <token>@projectversion@</token>
+                <value>${project.version}</value>
+              </replacement>
+              <replacement>
+                <token>@projectgroupid@</token>
+                <value>${project.groupId}</value>
+              </replacement>
+              <replacement>
+                <token>@projectartifactid@</token>
+                <value>${project.artifactId}</value>
+              </replacement>
+            </replacements>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
+</project>

--- a/plugin/src/test/resources/poms/oss-parent-56.pom
+++ b/plugin/src/test/resources/poms/oss-parent-56.pom
@@ -1,0 +1,658 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.fasterxml</groupId>
+  <artifactId>oss-parent</artifactId>
+  <version>56</version>
+  <packaging>pom</packaging>
+
+  <name>FasterXML.com parent pom</name>
+  <description>FasterXML.com parent pom</description>
+  <url>http://github.com/FasterXML/</url>
+  <organization>
+    <name>FasterXML</name>
+    <url>http://fasterxml.com/</url>
+  </organization>
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <!-- to fill in mostly by children, but stupid Sonatype REQUIRES
+       one developer already here
+    -->
+  <developers>
+    <developer>
+      <id>cowtowncoder</id>
+      <name>Tatu Saloranta</name>
+      <email>tatu@fasterxml.com</email>
+    </developer>
+  </developers>
+
+  <scm>
+    <connection>scm:git:git@github.com:FasterXML/oss-parent.git</connection>
+    <developerConnection>scm:git:git@github.com:FasterXML/oss-parent.git</developerConnection>
+    <url>http://github.com/FasterXML/oss-parent</url>
+    <tag>oss-parent-56</tag>
+  </scm>
+  <issueManagement>
+    <system>GitHub Issue Management</system>
+    <url>https://github.com/FasterXML/${project.artifactId}/issues</url>
+  </issueManagement>
+
+  <distributionManagement>
+    <snapshotRepository>
+      <id>sonatype-nexus-snapshots</id>
+      <name>Sonatype Nexus Snapshots</name>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+
+    <repository>
+      <id>sonatype-nexus-staging</id>
+      <name>Nexus Release Repository</name>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
+  </distributionManagement>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <!-- enable Reproducible Builds -->
+    <project.build.outputTimestamp>2023-11-07T02:34:42Z</project.build.outputTimestamp>
+
+    <generatedSourcesDir>${project.build.directory}/generated-sources</generatedSourcesDir>
+
+    <javadoc.maxmemory>1g</javadoc.maxmemory>
+
+    <!-- Use 1.6 as default baseline -->
+    <javac.src.version>1.6</javac.src.version>
+    <javac.target.version>1.6</javac.target.version>
+
+    <!-- By default, include all debug info; "vars" and "lines" both add 10-15% in size,
+         "source" very little
+     -->
+    <javac.debuglevel>lines,source,vars</javac.debuglevel>
+    <maven.build.timestamp.format>yyyy-MM-dd HH:mm:ssZ</maven.build.timestamp.format>
+    <!--
+     | Configuration properties for the OSGi maven-bundle-plugin
+    -->
+    <osgi.export>${project.groupId}.*;version=${project.version}</osgi.export>
+    <osgi.import>*</osgi.import>
+    <osgi.dynamicImport />
+    <osgi.private />
+    <osgi.requiredExecutionEnvironment />
+    <osgi.versionpolicy>${range;[===,=+);${@}}</osgi.versionpolicy>
+    <osgi.includeResource>{maven-resources}</osgi.includeResource>
+    <!-- 27-Dec-2015, tatu: Allow use of "Main-Class" too, default to empty -->
+    <osgi.mainClass />
+
+    <!--
+     | shared build/report plugins version
+    -->
+
+    <version.plugin.bundle>5.1.9</version.plugin.bundle>
+
+    <version.plugin.clean>3.3.2</version.plugin.clean>
+    <version.plugin.dependency>3.6.1</version.plugin.dependency>
+    <version.plugin.cobertura>2.7</version.plugin.cobertura>
+    <version.plugin.compiler>3.11.0</version.plugin.compiler>
+    <version.plugin.deploy>3.1.1</version.plugin.deploy>
+    <version.plugin.enforcer>3.4.1</version.plugin.enforcer>
+    <version.plugin.gpg>3.1.0</version.plugin.gpg>
+
+    <version.plugin.install>3.1.1</version.plugin.install>
+    <version.plugin.jacoco>0.8.10</version.plugin.jacoco>
+    <version.plugin.jar>3.3.0</version.plugin.jar>
+
+    <version.plugin.javadoc>3.6.0</version.plugin.javadoc>
+
+    <!-- 04-Mar-2019, latest property with v35, for Java 9+ Modules support 
+             (originally added in v34)
+     -->
+    <version.plugin.moditect>1.1.0</version.plugin.moditect>
+
+    <version.plugin.pmd>3.21.2</version.plugin.pmd>
+    <version.plugin.release>3.0.1</version.plugin.release>
+    <version.plugin.replacer>1.5.3</version.plugin.replacer>
+    <version.plugin.resources>3.3.1</version.plugin.resources>
+
+    <version.plugin.scm>2.0.1</version.plugin.scm>
+    <version.plugin.shade>3.5.1</version.plugin.shade>
+    <version.plugin.site>4.0.0-M11</version.plugin.site>
+
+    <version.plugin.source>3.3.0</version.plugin.source>
+
+    <version.plugin.surefire>3.2.1</version.plugin.surefire>
+
+    <version.plugin.wrapper>3.2.0</version.plugin.wrapper>
+
+    <!-- other "well-known" lib versions -->
+    <!-- 13-Oct-2020, 4.13 -> 4.13.1 (version 41) -->
+    <!-- 03-May-2020, 4.13.1 -> 4.13.2 (version 45) -->
+    <version.junit>4.13.2</version.junit>
+
+    <version.assertj>3.24.2</version.assertj>
+    
+  </properties>
+
+  <repositories>
+    <repository>
+      <id>sonatype-nexus-snapshots</id>
+      <name>Sonatype Nexus Snapshots</name>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>build-helper-maven-plugin</artifactId>
+          <version>3.4.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>${version.plugin.clean}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <version>${version.plugin.dependency}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>${version.plugin.deploy}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-gpg-plugin</artifactId>
+          <version>${version.plugin.gpg}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>${version.plugin.install}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>${version.plugin.javadoc}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>${version.plugin.resources}</version>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-shade-plugin</artifactId>
+          <version>${version.plugin.shade}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>${version.plugin.site}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>${version.plugin.source}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-wrapper-plugin</artifactId>
+          <version>${version.plugin.wrapper}</version>
+        </plugin>
+
+	<!-- 05-Dec-2018, tatu: v34 adds "moditect" plug-in, for Java 9+ Module support -->
+        <plugin>
+          <groupId>org.moditect</groupId>
+          <artifactId>moditect-maven-plugin</artifactId>
+          <version>${version.plugin.moditect}</version>
+        </plugin>
+
+        <plugin>
+          <!-- 26-Mar-2018, tatu: This is a weird component; up to 1.4.1 has
+                  artifact `maven-replacer-plugin`; from 1.5 just `replacer`?!?!
+            -->
+          <groupId>com.google.code.maven-replacer-plugin</groupId>
+          <artifactId>replacer</artifactId>
+<!--
+          <artifactId>maven-replacer-plugin</artifactId>
+-->
+          <version>${version.plugin.replacer}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>cobertura-maven-plugin</artifactId>
+          <version>${version.plugin.cobertura}</version>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.felix</groupId>
+          <artifactId>maven-bundle-plugin</artifactId>
+          <version>${version.plugin.bundle}</version>
+          <configuration>
+            <instructions>
+              <!--
+               | stops the "uses" clauses being added to "Export-Package" manifest entry
+              -->
+<!-- 04-Nov-2016, tatu: Not quite sure why it was disabled; see
+
+  https://github.com/FasterXML/jackson-jaxrs-providers/issues/93
+
+  for problem caused. Because of this, removed from Jackson 2.9
+
+              <_nouses>true</_nouses>
+-->
+
+              <!--
+               | Stop the JAVA_1_n_HOME variables from being treated as headers by Bnd
+              -->
+              <_removeheaders>Include-Resource,JAVA_1_3_HOME,JAVA_1_4_HOME,JAVA_1_5_HOME,JAVA_1_6_HOME,JAVA_1_7_HOME</_removeheaders>
+              <_versionpolicy>${osgi.versionpolicy}</_versionpolicy>
+              <Bundle-Name>${project.name}</Bundle-Name>
+              <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
+              <Bundle-Description>${project.description}</Bundle-Description>
+              <Export-Package>${osgi.export}</Export-Package>
+              <Private-Package>${osgi.private}</Private-Package>
+              <Import-Package>${osgi.import}</Import-Package>
+              <DynamicImport-Package>${osgi.dynamicImport}</DynamicImport-Package>
+              <Include-Resource>${osgi.includeResource}</Include-Resource>
+              <Bundle-DocURL>${project.url}</Bundle-DocURL>
+              <Bundle-RequiredExecutionEnvironment>${osgi.requiredExecutionEnvironment}</Bundle-RequiredExecutionEnvironment>
+
+              <X-Compile-Source-JDK>${javac.src.version}</X-Compile-Source-JDK>
+              <X-Compile-Target-JDK>${javac.target.version}</X-Compile-Target-JDK>
+
+              <Implementation-Title>${project.name}</Implementation-Title>
+              <Implementation-Version>${project.version}</Implementation-Version>
+              <Implementation-Vendor-Id>${project.groupId}</Implementation-Vendor-Id>
+              <Implementation-Vendor>${project.organization.name}</Implementation-Vendor>
+
+              <Specification-Title>${project.name}</Specification-Title>
+              <Specification-Version>${project.version}</Specification-Version>
+              <Specification-Vendor>${project.organization.name}</Specification-Vendor>
+
+              <Main-Class>${osgi.mainClass}</Main-Class>
+            </instructions>
+          </configuration>
+        </plugin>
+
+        <!-- Plug-in settings needed for Maven/Nexus release handling
+          -->
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-release-plugin</artifactId>
+          <version>${version.plugin.release}</version>
+          <configuration>
+            <mavenExecutorId>forked-path</mavenExecutorId>
+            <useReleaseProfile>false</useReleaseProfile>
+            <arguments>-Prelease</arguments>
+          </configuration>
+        </plugin>
+	<!-- 05-Mar-2021, tatu: I don't think this is in use at all?
+
+        <plugin>
+          <groupId>org.sonatype.plugins</groupId>
+          <artifactId>nexus-maven-plugin</artifactId>
+          <version>2.1</version>
+          <configuration>
+            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+            <serverAuthId>sonatype-nexus-staging</serverAuthId>
+          </configuration>
+        </plugin>
+-->
+
+      </plugins>
+    </pluginManagement>
+
+    <plugins>
+      <!-- In Alphabetic order by 'artifactId' -->
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>add-generated-sources</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>${generatedSourcesDir}</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>${version.plugin.jacoco}</version>
+      </plugin>
+      
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${version.plugin.compiler}</version>
+        <!-- 05-Dec-2018, tatu: Looks like override needed for some reason 
+          (probably for Java 9+ Module support) 
+        -->
+        <dependencies>
+          <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm</artifactId>
+            <version>9.6</version>
+          </dependency>
+        </dependencies>
+        <configuration>
+          <source>${javac.src.version}</source>
+          <target>${javac.target.version}</target>
+          <showDeprecation>true</showDeprecation>
+          <showWarnings>true</showWarnings>
+          <!-- 16-Apr-2013, tatu: As per Nick W's suggestions, let's 
+              use these to reduce jar size 
+            -->
+          <debug>true</debug>
+          <debuglevel>${javac.debuglevel}</debuglevel>
+        </configuration>
+      </plugin>
+      
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>${version.plugin.enforcer}</version>
+        <executions>
+          <execution>
+            <id>enforce-java</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <!-- 08-Aug-2017, tatu: No FX/CTC lib allows 1.5 any more -->
+                <requireJavaVersion>
+                  <version>[1.6,)</version>
+                  <message>[ERROR] The currently supported version of Java is 1.6 or higher</message>
+                </requireJavaVersion>
+                <requireMavenVersion>
+                  <version>[3.0,)</version>
+                  <message>[ERROR] The currently supported version of Maven is 3.0 or higher</message>
+                </requireMavenVersion>
+                <requirePluginVersions>
+                  <banLatest>true</banLatest>
+                  <banRelease>true</banRelease>
+                  <banSnapshots>true</banSnapshots>
+                  <phases>clean,deploy,site</phases>
+                  <message>[ERROR] Best Practice is to always define plugin versions!</message>
+                </requirePluginVersions>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+      </plugin>
+      
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>${version.plugin.jar}</version>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-scm-plugin</artifactId>
+        <version>${version.plugin.scm}</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.maven.scm</groupId>
+            <artifactId>maven-scm-provider-gitexe</artifactId>
+            <version>${version.plugin.scm}</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-site-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-descriptor</id>
+            <goals>
+              <goal>attach-descriptor</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${version.plugin.surefire}</version>
+      </plugin>
+
+    </plugins>
+
+    <extensions>
+      <extension>
+        <groupId>org.apache.maven.scm</groupId>
+        <artifactId>maven-scm-provider-gitexe</artifactId>
+        <version>${version.plugin.scm}</version>
+      </extension>
+
+      <extension>
+        <groupId>org.apache.maven.scm</groupId>
+        <artifactId>maven-scm-manager-plexus</artifactId>
+        <version>${version.plugin.scm}</version>
+      </extension>
+
+      <!-- WTH is this? -->
+      <extension>
+        <groupId>org.kathrynhuxtable.maven.wagon</groupId>
+        <artifactId>wagon-gitsite</artifactId>
+        <version>0.3.1</version>
+      </extension>
+    </extensions>
+  </build>
+
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>${version.plugin.javadoc}</version>
+        <configuration>
+          <bootclasspath>${sun.boot.class.path}</bootclasspath>
+          <doclet>com.google.doclava.Doclava</doclet>
+          <useStandardDocletOptions>false</useStandardDocletOptions>
+          <additionalJOption>-J-Xmx1024m</additionalJOption>
+          <maxmemory>${javadoc.maxmemory}</maxmemory>
+          <links>
+            <link>http://docs.oracle.com/javase/8/docs/api/</link>
+          </links>
+          <docletArtifact>
+            <groupId>com.google.doclava</groupId>
+            <artifactId>doclava</artifactId>
+            <version>1.0.3</version>
+          </docletArtifact>
+          <additionalparam>
+            -hdf project.name "${project.name}"
+            -d ${project.reporting.outputDirectory}/apidocs
+          </additionalparam>
+        </configuration>
+        <reportSets>
+          <reportSet>
+            <id>default</id>
+            <reports>
+              <report>javadoc</report>
+            </reports>
+          </reportSet>
+        </reportSets>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-project-info-reports-plugin</artifactId>
+        <version>3.4.5</version>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jxr-plugin</artifactId>
+        <version>3.3.1</version>
+      </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>jdepend-maven-plugin</artifactId>
+        <version>2.0</version>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-report-plugin</artifactId>
+        <version>${version.plugin.surefire}</version>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-pmd-plugin</artifactId>
+        <version>${version.plugin.pmd}</version>
+        <configuration>
+          <linkXref>true</linkXref>
+          <minimumTokens>100</minimumTokens>
+          <targetJdk>1.5</targetJdk>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>taglist-maven-plugin</artifactId>
+        <version>3.0.0</version>
+        <configuration>
+          <tagListOptions>
+            <tagClasses>
+              <tagClass>
+                <displayName>Todo Work</displayName>
+                <tags>
+                  <tag>
+                    <matchString>TODO</matchString>
+                    <matchType>ignoreCase</matchType>
+                  </tag>
+                  <tag>
+                    <matchString>FIXME</matchString>
+                    <matchType>ignoreCase</matchType>
+                  </tag>
+                </tags>
+              </tagClass>
+            </tagClasses>
+          </tagListOptions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </reporting>
+
+  <profiles>
+    <profile>
+      <id>release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>${version.plugin.source}</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+                <configuration>
+                  <archive>
+                    <manifest>
+                      <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                      <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+                    </manifest>
+                    <manifestEntries>
+                      <X-Compile-Source-JDK>${javac.src.version}</X-Compile-Source-JDK>
+                      <X-Compile-Target-JDK>${javac.target.version}</X-Compile-Target-JDK>
+                    </manifestEntries>
+                  </archive>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>${version.plugin.javadoc}</version>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+                <configuration>
+                  <quiet>true</quiet>
+                  <archive>
+                    <manifest>
+                      <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                      <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+                    </manifest>
+                    <manifestEntries>
+                      <X-Compile-Source-JDK>${javac.src.version}</X-Compile-Source-JDK>
+                      <X-Compile-Target-JDK>${javac.target.version}</X-Compile-Target-JDK>
+                    </manifestEntries>
+                  </archive>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
+</project>


### PR DESCRIPTION
# Description
Provide the ability for users to easily override the properties that are present in the root BOM. This will only work if the version is specified via a property.

For example, in `spring-boot-dependencies`, provide the ability to override the `jackson-bom` property value.

closes #95 