### PR TITLE
Use Published TOML Artifacts

### DIFF
--- a/plugin/src/docs/asciidoc/detailed-usage/sources.adoc
+++ b/plugin/src/docs/asciidoc/detailed-usage/sources.adoc
@@ -113,5 +113,5 @@ dependencyResolutionmanagement {
 <1> You can also use the standard string notation to specify your dependency
 <2> More conveniently, you can pass the string notation directly into `from()`
 
-NOTE: Groovy is not my strong point so it's possible there is simpler / better syntax I'm not aware of. If you have
-any improvements please open an issue or a PR.
+NOTE: Groovy is not my strong point so it's likely that there is simpler / better syntax I'm not aware of. If you have
+any suggestions to improve the syntax in the documentation please open an issue or a PR.

--- a/plugin/src/docs/asciidoc/detailed-usage/sources.adoc
+++ b/plugin/src/docs/asciidoc/detailed-usage/sources.adoc
@@ -19,6 +19,14 @@ dependencyResolutionmanagement {
     generate("awsLibs") {
       from(toml("awsBom")) // <3>
     }
+    generate("junitLibs") {
+      from {
+        toml {
+          libraryAlias = "boms-junit5"
+          file = dependency("io.micronaut.platform:micronaut-platform:4.3.6") // <4>
+        }
+      }
+    }
   }
 }
 ----
@@ -26,6 +34,8 @@ dependencyResolutionmanagement {
 <2> The TOML file to find the provided alias in. This only needs to be provided
 if _not_ using the value `gradle/libs.versions.toml`
 <3> When using the default file, you can use the convenience function `toml(..)` and just provide the alias name
+<4> If your TOML is published to a repository, you can fetch it using the `dependency` function and standard string
+notation.
 
 .settings.gradle
 [source,groovy,subs="attributes+",role="secondary"]
@@ -43,6 +53,14 @@ dependencyResolutionmanagement {
     generator.generate("awsLibs") {
       it.from(it.toml("spring-boot-dependencies")) // <3>
     }
+    generate("junitLibs") {
+      it.from { from ->
+        from.toml { toml ->
+          toml.libraryAlias = "boms-junit5"
+          toml.file = toml.dependency("io.micronaut.platform:micronaut-platform:4.3.6") // <4>
+        }
+      }
+    }
   }
 }
 ----
@@ -50,7 +68,8 @@ dependencyResolutionmanagement {
 <2> The TOML file to find the provided alias in. This only needs to be provided
 if _not_ using the value `gradle/libs.versions.toml`
 <3> When using the default file, you can use the convenience function `toml(..)` and just provide the alias name
-
+<4> If your TOML is published to a repository, you can fetch it using the `dependency` function and standard string
+notation.
 
 TIP: GitHub's Dependabot only supports automatic updates in the default version catalog `gradle/libs.versions.toml`
 

--- a/plugin/src/docs/asciidoc/detailed-usage/sources.adoc
+++ b/plugin/src/docs/asciidoc/detailed-usage/sources.adoc
@@ -23,7 +23,7 @@ dependencyResolutionmanagement {
       from {
         toml {
           libraryAlias = "boms-junit5"
-          file = dependency("io.micronaut.platform:micronaut-platform:4.3.6") // <4>
+          file = artifact("io.micronaut.platform:micronaut-platform:4.3.6") // <4>
         }
       }
     }
@@ -34,7 +34,7 @@ dependencyResolutionmanagement {
 <2> The TOML file to find the provided alias in. This only needs to be provided
 if _not_ using the value `gradle/libs.versions.toml`
 <3> When using the default file, you can use the convenience function `toml(..)` and just provide the alias name
-<4> If your TOML is published to a repository, you can fetch it using the `dependency` function and standard string
+<4> If your TOML is published to a repository, you can fetch it using the `artifact` function and standard string
 notation.
 
 .settings.gradle
@@ -57,7 +57,7 @@ dependencyResolutionmanagement {
       it.from { from ->
         from.toml { toml ->
           toml.libraryAlias = "boms-junit5"
-          toml.file = toml.dependency("io.micronaut.platform:micronaut-platform:4.3.6") // <4>
+          toml.file = toml.artifact("io.micronaut.platform:micronaut-platform:4.3.6") // <4>
         }
       }
     }
@@ -68,7 +68,7 @@ dependencyResolutionmanagement {
 <2> The TOML file to find the provided alias in. This only needs to be provided
 if _not_ using the value `gradle/libs.versions.toml`
 <3> When using the default file, you can use the convenience function `toml(..)` and just provide the alias name
-<4> If your TOML is published to a repository, you can fetch it using the `dependency` function and standard string
+<4> If your TOML is published to a repository, you can fetch it using the `artifact` function and standard string
 notation.
 
 TIP: GitHub's Dependabot only supports automatic updates in the default version catalog `gradle/libs.versions.toml`

--- a/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/Generator.kt
+++ b/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/Generator.kt
@@ -4,6 +4,7 @@ import dev.aga.gradle.versioncatalogs.model.PropertyOverride
 import dev.aga.gradle.versioncatalogs.model.Version
 import dev.aga.gradle.versioncatalogs.service.DependencyResolver
 import dev.aga.gradle.versioncatalogs.service.GradleDependencyResolver
+import dev.aga.gradle.versioncatalogs.service.PublishedArtifactResolver
 import dev.aga.gradle.versioncatalogs.tasks.SaveTask
 import java.io.File
 import java.util.*
@@ -72,7 +73,8 @@ object Generator {
         name: String,
         conf: VersionCatalogGeneratorPluginExtension,
     ): VersionCatalogBuilder {
-        val resolver = GradleDependencyResolver(conf.objects, dependencyResolutionServices)
+        val artifactResolver = PublishedArtifactResolver(conf.objects, dependencyResolutionServices)
+        val resolver = GradleDependencyResolver(artifactResolver)
         return generate(name, conf.objects, conf.config, resolver)
     }
 

--- a/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/Generator.kt
+++ b/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/Generator.kt
@@ -5,10 +5,10 @@ import dev.aga.gradle.versioncatalogs.model.Version
 import dev.aga.gradle.versioncatalogs.service.DependencyResolver
 import dev.aga.gradle.versioncatalogs.service.GradleDependencyResolver
 import dev.aga.gradle.versioncatalogs.service.PublishedArtifactResolver
+import dev.aga.gradle.versioncatalogs.service.dependencyResolutionServices
 import dev.aga.gradle.versioncatalogs.tasks.SaveTask
 import java.io.File
 import java.util.*
-import java.util.function.Supplier
 import kotlin.collections.ArrayDeque
 import kotlin.collections.component1
 import kotlin.collections.component2
@@ -21,7 +21,6 @@ import org.gradle.api.Project
 import org.gradle.api.initialization.Settings
 import org.gradle.api.initialization.dsl.VersionCatalogBuilder
 import org.gradle.api.initialization.resolve.MutableVersionCatalogContainer
-import org.gradle.api.internal.artifacts.DependencyResolutionServices
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.kotlin.dsl.register
@@ -454,19 +453,4 @@ object Generator {
 
     internal fun cachedCatalogName(name: String, dep: Dependency) =
         "libs.${name}-${dep.artifactId}-${dep.version}.toml"
-
-    /*
-    Below methods inspired by / taken from
-     https://github.com/F43nd1r/bomVersionCatalog/blob/master/bom-version-catalog/src/main/kotlin/com/faendir/gradle/extensions.kt
-     */
-    private val MutableVersionCatalogContainer.dependencyResolutionServices:
-        Supplier<DependencyResolutionServices>
-        get() = accessField("dependencyResolutionServices")
-
-    private fun <T> MutableVersionCatalogContainer.accessField(name: String): T {
-        return this.javaClass.superclass
-            .getDeclaredField(name)
-            .apply { isAccessible = true }
-            .get(this) as T
-    }
 }

--- a/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/GeneratorConfig.kt
+++ b/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/GeneratorConfig.kt
@@ -246,6 +246,11 @@ class GeneratorConfig(val settings: Settings) {
         var file: File =
             settings.rootDir.toPath().resolve(Paths.get("gradle", "libs.versions.toml")).toFile()
 
+        /**
+         * If your TOML is a published artifact that can be found in one of the repositories you
+         * have configured, you can use the dependency notation `groupId:artifactId:version` to
+         * fetch the TOML from the repository.
+         */
         lateinit var dependency: String
 
         internal fun isInitialized(): Boolean {

--- a/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/GeneratorConfig.kt
+++ b/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/GeneratorConfig.kt
@@ -243,10 +243,10 @@ class GeneratorConfig(val settings: Settings) {
          * `groupId:artifactId:version` to fetch the TOML from the repository.
          *
          * ```kotlin
-         * file = dependency("io.micrometer.platform:micrometer-platform:4.3.6")
+         * file = artifact("io.micrometer.platform:micrometer-platform:4.3.6")
          * ```
          */
-        fun dependency(notation: String): File {
+        fun artifact(notation: String): File {
             return with(settings.dependencyResolutionManagement.versionCatalogs) {
                 val par = PublishedArtifactResolver(objects, dependencyResolutionServices)
                 val dep = notation.toDependency()

--- a/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/service/ArtifactResolver.kt
+++ b/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/service/ArtifactResolver.kt
@@ -1,0 +1,8 @@
+package dev.aga.gradle.versioncatalogs.service
+
+import java.io.File
+import org.apache.maven.model.Dependency
+
+interface ArtifactResolver {
+    fun resolve(dep: Dependency, type: String = "pom"): File
+}

--- a/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/service/GradleDependencyResolver.kt
+++ b/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/service/GradleDependencyResolver.kt
@@ -1,66 +1,32 @@
 package dev.aga.gradle.versioncatalogs.service
 
-import dev.aga.gradle.versioncatalogs.exception.ResolutionException
-import java.util.concurrent.atomic.AtomicInteger
-import java.util.function.Supplier
 import org.apache.maven.model.Dependency
 import org.apache.maven.model.Model
-import org.gradle.api.artifacts.Configuration
-import org.gradle.api.artifacts.ExternalDependency
-import org.gradle.api.attributes.Category
-import org.gradle.api.internal.artifacts.DependencyResolutionServices
-import org.gradle.api.internal.artifacts.dependencies.DefaultDependencyArtifact
-import org.gradle.api.model.ObjectFactory
 
 class GradleDependencyResolver(
-    private val objects: ObjectFactory,
-    private val drsSupplier: Supplier<DependencyResolutionServices>,
+    private val artifactResolver: ArtifactResolver,
     parentModelResolver: DependencyResolver? = null,
 ) : DependencyResolver {
-    private val drs by lazy { drsSupplier.get() }
 
     private val parentModelResolver = parentModelResolver ?: this
 
     override fun resolve(source: Dependency): Pair<Model, Model?> {
-        val config = createConfiguration()
-        registerDependency(config, source)
-
-        return config.incoming.artifacts.firstOrNull()?.let {
-            val path = it.file.toPath()
-            val resolver = LocalDependencyResolver(path)
-            val model = resolver.resolve()
-            decorate(source, model)
-            val parentDep =
-                model.parent?.let { parent ->
-                    Dependency().apply {
-                        groupId = parent.groupId ?: source.groupId
-                        artifactId = parent.artifactId
-                        version = parent.version ?: source.version
-                    }
+        val fetchedFile = artifactResolver.resolve(source, "pom")
+        val resolver = LocalDependencyResolver(fetchedFile.toPath())
+        val model = resolver.resolve()
+        decorate(source, model)
+        val parentDep =
+            model.parent?.let { parent ->
+                Dependency().apply {
+                    groupId = parent.groupId ?: source.groupId
+                    artifactId = parent.artifactId
+                    version = parent.version ?: source.version
                 }
+            }
 
-            val parentModel = parentDep?.let { pd -> parentModelResolver.resolve(pd) }
+        val parentModel = parentDep?.let { pd -> parentModelResolver.resolve(pd) }
 
-            model to parentModel?.first
-        } ?: throw ResolutionException("Unable to resolve ${source}")
-    }
-
-    private fun registerDependency(config: Configuration, source: Dependency) {
-        val dep =
-            drs.dependencyHandler.create("${source.groupId}:${source.artifactId}:${source.version}")
-        when (dep) {
-            is ExternalDependency ->
-                dep.addArtifact(
-                    DefaultDependencyArtifact(
-                        dep.name,
-                        "pom",
-                        "pom",
-                        null,
-                        null,
-                    ),
-                )
-        }
-        config.dependencies.add(dep)
+        return model to parentModel?.first
     }
 
     private fun decorate(source: Dependency, target: Model) {
@@ -72,26 +38,5 @@ class GradleDependencyResolver(
             artifactId = source.artifactId
             version = source.version
         }
-    }
-
-    private fun createConfiguration(): Configuration {
-        val config =
-            drs.configurationContainer.create("incomingBom${configurationCount.incrementAndGet()}")
-
-        return config.apply {
-            resolutionStrategy.activateDependencyLocking()
-            attributes {
-                attribute(
-                    Category.CATEGORY_ATTRIBUTE,
-                    objects.named(Category::class.java, Category.REGULAR_PLATFORM),
-                )
-            }
-            isCanBeResolved = true
-            isCanBeConsumed = false
-        }
-    }
-
-    companion object {
-        private val configurationCount = AtomicInteger(0)
     }
 }

--- a/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/service/PublishedArtifactResolver.kt
+++ b/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/service/PublishedArtifactResolver.kt
@@ -1,0 +1,68 @@
+package dev.aga.gradle.versioncatalogs.service
+
+import dev.aga.gradle.versioncatalogs.exception.ResolutionException
+import java.io.File
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.function.Supplier
+import org.apache.maven.model.Dependency
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.ExternalDependency
+import org.gradle.api.attributes.Category
+import org.gradle.api.internal.artifacts.DependencyResolutionServices
+import org.gradle.api.internal.artifacts.dependencies.DefaultDependencyArtifact
+import org.gradle.api.model.ObjectFactory
+
+class PublishedArtifactResolver(
+    private val objects: ObjectFactory,
+    private val drsSupplier: Supplier<DependencyResolutionServices>,
+) : ArtifactResolver {
+    private val drs by lazy { drsSupplier.get() }
+
+    override fun resolve(dep: Dependency, type: String): File {
+        val config = createConfiguration()
+        registerDependency(config, dep, type)
+        return config.incoming.artifacts.firstOrNull()?.file
+            ?: throw ResolutionException("Unable to resolve ${dep} with type ${type}")
+    }
+
+    private fun registerDependency(config: Configuration, source: Dependency, type: String) {
+        val dep =
+            drs.dependencyHandler.create("${source.groupId}:${source.artifactId}:${source.version}")
+        when (dep) {
+            is ExternalDependency ->
+                dep.addArtifact(
+                    DefaultDependencyArtifact(
+                        dep.name,
+                        type,
+                        type,
+                        null,
+                        null,
+                    ),
+                )
+        }
+        config.dependencies.add(dep)
+    }
+
+    private fun createConfiguration(): Configuration {
+        val config =
+            drs.configurationContainer.create(
+                "incomingConfiguration${configurationCount.incrementAndGet()}",
+            )
+
+        return config.apply {
+            resolutionStrategy.activateDependencyLocking()
+            attributes {
+                attribute(
+                    Category.CATEGORY_ATTRIBUTE,
+                    objects.named(Category::class.java, Category.REGULAR_PLATFORM),
+                )
+            }
+            isCanBeResolved = true
+            isCanBeConsumed = false
+        }
+    }
+
+    companion object {
+        private val configurationCount = AtomicInteger(0)
+    }
+}

--- a/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/service/Reflection.kt
+++ b/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/service/Reflection.kt
@@ -1,0 +1,22 @@
+package dev.aga.gradle.versioncatalogs.service
+
+import java.util.function.Supplier
+import org.gradle.api.initialization.resolve.MutableVersionCatalogContainer
+import org.gradle.api.internal.artifacts.DependencyResolutionServices
+import org.gradle.api.model.ObjectFactory
+
+internal val MutableVersionCatalogContainer.objects: ObjectFactory
+    get() = accessField("objects")
+
+/*
+Below methods inspired by / taken from
+ https://github.com/F43nd1r/bomVersionCatalog/blob/master/bom-version-catalog/src/main/kotlin/com/faendir/gradle/extensions.kt
+ */
+internal val MutableVersionCatalogContainer.dependencyResolutionServices:
+    Supplier<DependencyResolutionServices>
+    get() = accessField("dependencyResolutionServices")
+
+internal fun <T> MutableVersionCatalogContainer.accessField(name: String): T {
+    return this.javaClass.superclass.getDeclaredField(name).apply { isAccessible = true }.get(this)
+        as T
+}

--- a/plugin/src/test/kotlin/dev/aga/gradle/versioncatalogs/VersionCatalogGeneratorPluginTest.kt
+++ b/plugin/src/test/kotlin/dev/aga/gradle/versioncatalogs/VersionCatalogGeneratorPluginTest.kt
@@ -166,7 +166,7 @@ class VersionCatalogGeneratorPluginTest {
                    def suffix = aliasSuffixGenerator.invoke(prefix, groupId, artifactId)
                    DEFAULT_ALIAS_GENERATOR.invoke(prefix,suffix)
                   }
-                  it.versionNameGenerator = it.DEFAULT_VERSION_NAME_GENERATOR
+                  it.versionNameGenerator = DEFAULT_VERSION_NAME_GENERATOR
                 }
                 
                 generator.generate("mockitoLibs") {
@@ -176,7 +176,16 @@ class VersionCatalogGeneratorPluginTest {
                       def suffix = aliasSuffixGenerator.invoke(prefix, groupId, artifactId)
                       DEFAULT_ALIAS_GENERATOR.invoke(prefix,suffix)
                     }
-                    it.versionNameGenerator = it.DEFAULT_VERSION_NAME_GENERATOR
+                    it.versionNameGenerator = DEFAULT_VERSION_NAME_GENERATOR
+                }
+                generator.generate("junitLibs") {
+                  it.from { from ->
+                    from.toml { toml ->
+                      toml.libraryAlias = "boms-junit5"
+                      toml.dependency = "io.micronaut.platform:micronaut-platform:4.3.6"
+                    }
+                  }
+                  it.aliasPrefixGenerator = NO_PREFIX
                 }
               }
             }
@@ -192,6 +201,7 @@ class VersionCatalogGeneratorPluginTest {
               implementation(jsonLibs.jackson.jacksonDatabind)
               implementation(jsonLibs.bundles.jacksonModule)
               testImplementation(mockitoLibs.mockito.mockitoCore)
+              testImplementation(junitLibs.junitJupiter)
             }
             """
                 .trimIndent(),

--- a/plugin/src/test/kotlin/dev/aga/gradle/versioncatalogs/VersionCatalogGeneratorPluginTest.kt
+++ b/plugin/src/test/kotlin/dev/aga/gradle/versioncatalogs/VersionCatalogGeneratorPluginTest.kt
@@ -82,7 +82,7 @@ class VersionCatalogGeneratorPluginTest {
                   from {
                     toml {
                       libraryAlias = "boms-junit5"
-                      dependency = "io.micronaut.platform:micronaut-platform:4.3.6"
+                      file = dependency("io.micronaut.platform:micronaut-platform:4.3.6")
                     }
                   }
                   aliasPrefixGenerator = GeneratorConfig.NO_PREFIX
@@ -182,7 +182,7 @@ class VersionCatalogGeneratorPluginTest {
                   it.from { from ->
                     from.toml { toml ->
                       toml.libraryAlias = "boms-junit5"
-                      toml.dependency = "io.micronaut.platform:micronaut-platform:4.3.6"
+                      toml.file = toml.dependency("io.micronaut.platform:micronaut-platform:4.3.6")
                     }
                   }
                   it.aliasPrefixGenerator = NO_PREFIX

--- a/plugin/src/test/kotlin/dev/aga/gradle/versioncatalogs/VersionCatalogGeneratorPluginTest.kt
+++ b/plugin/src/test/kotlin/dev/aga/gradle/versioncatalogs/VersionCatalogGeneratorPluginTest.kt
@@ -74,14 +74,19 @@ class VersionCatalogGeneratorPluginTest {
                   }
                   cacheEnabled = true
                 }
-                generate("junitLibs") {
-                  from("org.junit:junit-bom:5.10.0")
-                  aliasPrefixGenerator = GeneratorConfig.NO_PREFIX
-                  cacheEnabled = true
-                }
                 generate("awsLibs") {
                   from(toml("aws-bom"))
                   aliasPrefixGenerator = GeneratorConfig.NO_PREFIX
+                }
+                generate("junitLibs") {
+                  from {
+                    toml {
+                      libraryAlias = "boms-junit5"
+                      dependency = "io.micronaut.platform:micronaut-platform:4.3.6"
+                    }
+                  }
+                  aliasPrefixGenerator = GeneratorConfig.NO_PREFIX
+                  cacheEnabled = true
                 }
               }
             }
@@ -131,7 +136,7 @@ class VersionCatalogGeneratorPluginTest {
         assertThat(projectDir.resolve(Paths.get("build", "version-catalogs").toString()))
             .isDirectoryNotContaining { it.name == "libs.awsLibs-bom-2.21.15.toml" }
             .isDirectoryContaining { it.name == "libs.jsonLibs-jackson-bom-2.15.2.toml" }
-            .isDirectoryContaining { it.name == "libs.junitLibs-junit-bom-5.10.0.toml" }
+            .isDirectoryContaining { it.name == "libs.junitLibs-junit-bom-5.10.2.toml" }
             .isDirectoryContaining { it.name == "libs.mockitoLibs-mockito-bom-5.5.0.toml" }
     }
 

--- a/plugin/src/test/kotlin/dev/aga/gradle/versioncatalogs/VersionCatalogGeneratorPluginTest.kt
+++ b/plugin/src/test/kotlin/dev/aga/gradle/versioncatalogs/VersionCatalogGeneratorPluginTest.kt
@@ -82,7 +82,7 @@ class VersionCatalogGeneratorPluginTest {
                   from {
                     toml {
                       libraryAlias = "boms-junit5"
-                      file = dependency("io.micronaut.platform:micronaut-platform:4.3.6")
+                      file = artifact("io.micronaut.platform:micronaut-platform:4.3.6")
                     }
                   }
                   aliasPrefixGenerator = GeneratorConfig.NO_PREFIX
@@ -182,7 +182,7 @@ class VersionCatalogGeneratorPluginTest {
                   it.from { from ->
                     from.toml { toml ->
                       toml.libraryAlias = "boms-junit5"
-                      toml.file = toml.dependency("io.micronaut.platform:micronaut-platform:4.3.6")
+                      toml.file = toml.artifact("io.micronaut.platform:micronaut-platform:4.3.6")
                     }
                   }
                   it.aliasPrefixGenerator = NO_PREFIX

--- a/plugin/src/test/kotlin/dev/aga/gradle/versioncatalogs/service/MockGradleDependencyResolver.kt
+++ b/plugin/src/test/kotlin/dev/aga/gradle/versioncatalogs/service/MockGradleDependencyResolver.kt
@@ -50,7 +50,8 @@ class MockGradleDependencyResolver(val rootDir: Path) : DependencyResolver {
 
     init {
         val supp: Supplier<DependencyResolutionServices> = Supplier { drs }
-        delegate = GradleDependencyResolver(objectFactory, supp, this)
+        val artifactResolver = PublishedArtifactResolver(objectFactory, supp)
+        delegate = GradleDependencyResolver(artifactResolver, this)
     }
 
     override fun resolve(source: Dependency): Pair<Model, Model?> {


### PR DESCRIPTION
# Description
Adds the ability to use a published (maven, nexus, etc) TOML file as the source of your TOML library alias

closes #107 