### PR TITLE
More specially handled prefixes

### DIFF
--- a/plugin/src/docs/asciidoc/detailed-usage/naming.adoc
+++ b/plugin/src/docs/asciidoc/detailed-usage/naming.adoc
@@ -42,6 +42,7 @@ set up. If you do not wish to use the aliases, you will need to provide your own
 | Group begins with | `org.neo4j` | `neo4j`
 | Group begins with | `io.projectreactor` | `projectreactor`
 | Group begins with | `io.zipkin` | `zipkin`
+| Group begins with | `io.dropwizard` | `dropwizard`
 | Group begins with | `jakarta.` | `jakarta`
 | Group begins with | `commons-` | `commons`
 | Group begins with | `androidx` | `androidx`

--- a/plugin/src/docs/asciidoc/detailed-usage/naming.adoc
+++ b/plugin/src/docs/asciidoc/detailed-usage/naming.adoc
@@ -16,9 +16,36 @@ The default algorithm is as follows:
 last two items in the list are concatenated by a hyphen. The entirety of the string is the converted to camelCase
 4. In any other scenario, the last item in the list is returned as-is
 
-NOTE: Due to the popularity of the Spring Framework and the Jackson json mapping libraries, special cases have been added
-to simplify their generated naming conventions. If any groupId _begins_ with `com.fasterxml.jackson`, the prefix `jackson` will
-be emitted, while any groupId _beginning_ with `org.springframework` will emit the prefix `spring`.
+NOTE: Due to the popularity of many packages that may not necessarily fit our algorithm, a number of special cases have
+been added to simplify their generated prefixes. Please refer to the below table for the hardcoded aliases we have
+set up. If you do not wish to use the aliases, you will need to provide your own prefix generation function.
+
+[cols="3*", options="header"]
+|===
+| Condition         | Value | Generated Prefix
+| Group begins with | `com.fasterxml.jackson` | `jackson`
+| Group begins with | `com.oracle.database` | `oracle`
+| Group begins with | `com.google.android` | `android`
+| Group begins with | `com.facebook` | `facebook`
+| Group begins with | `org.springframework` | `spring`
+| Group begins with | `org.hibernate` | `hibernate`
+| Group begins with | `org.apache.httpcomponents` | `httpcomponents`
+| Group begins with | `org.apache.tomcat` | `tomcat`
+| Group begins with | `org.eclipse.jetty` | `jetty`
+| Group begins with | `org.elasticsearch` | `elasticsearch`
+| Group begins with | `org.firebirdsql` | `firebird`
+| Group begins with | `org.glassfish.jersey` | `jersey`
+| Group begins with | `org.jetbrains.kotlinx` | `kotlinx`
+| Group begins with | `org.jetbrains.kotlin` | `kotlin`
+| Group begins with | `org.junit` | `junit`
+| Group begins with | `org.mariadb` | `mariadb`
+| Group begins with | `org.neo4j` | `neo4j`
+| Group begins with | `io.projectreactor` | `projectreactor`
+| Group begins with | `io.zipkin` | `zipkin`
+| Group begins with | `jakarta.` | `jakarta`
+| Group begins with | `commons-` | `commons`
+| Group begins with | `androidx` | `androidx`
+|===
 
 ===== Suffix Generation
 1. Replace any `.` character in the `artifactId` of the dependency with a `-`

--- a/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/GeneratorConfig.kt
+++ b/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/GeneratorConfig.kt
@@ -278,13 +278,36 @@ class GeneratorConfig(val settings: Settings) {
         }
 
         /**
-         * Default function to generate the prefix of the library's alias. If the `groupId` starts
-         * with `com.fasterxml.jackson`, we return `jackson`. If the `groupId` starts with
-         * `org.springframework`, we return `spring`. Otherwise, the below logic applies:
+         * Default function to generate the prefix of the library's alias. There are a series of
+         * special cases we handle to make the prefix generation "nicer":
+         * 1. The group prefix is `com.fasterxml.jackson`: `jackson`
+         * 2. The group prefix is `com.oracle.database`: `oracle`
+         * 3. The group prefix is `com.google.android`: `android`
+         * 4. The group prefix is `com.facebook`: `facebook`
+         * 5. The group prefix is `org.springframework`: `spring`
+         * 6. The group prefix is `org.hibernate`: `hibernate`
+         * 7. The group prefix is `org.apache.httpcomponents`: `httpcomponents`
+         * 8. The group prefix is `org.apache.tomcat`: `tomcat`
+         * 9. The group prefix is `org.eclipse.jetty`: `jetty`
+         * 10. The group prefix is `org.elasticsearch`: `elasticsearch`
+         * 11. The group prefix is `org.firebirdsql`: `firebird`
+         * 12. The group prefix is `org.glassfish.jersey`: `jersey`
+         * 13. The group prefix is `org.jetbrains.kotlinx`: `kotlinx`
+         * 14. The group prefix is `org.jetbrains.kotlin`: `kotlin`
+         * 15. The group prefix is `org.junit`: `junit`
+         * 16. The group prefix is `org.mariadb`: `mariadb`
+         * 17. The group prefix is `org.neo4j`: `neo4j`
+         * 18. The group prefix is `io.projectreactor`: `projectreactor`
+         * 19. The group prefix is `io.zipkin`: `zipkin`
+         * 20. The group prefix is `jakarta.`: `jakarta`
+         * 21. The group prefix is `commons-`: `commons`
+         * 22. The group prefix is `androidx`: `androidx`
+         *
+         * If none of the above prefixes match, the logic is as follows:
          * 1. The `groupId` is split by `.`
          * 2. If the split only returns a list of one item and the value is any one of
          *    [INVALID_PREFIXES], an [IllegalArgumentException] is thrown.
-         * 3. Otherwise if the split returns a list of more than one item and the last value is any
+         * 3. Otherwise, if the split returns a list of more than one item and the last value is any
          *    one of [INVALID_PREFIXES], the last two values are concatenated with a `-` and then
          *    the entirety of the string is converted to camelCase
          * 4. In any other scenario, the last item in the list is returned
@@ -389,14 +412,7 @@ class GeneratorConfig(val settings: Settings) {
                     ),
                 "io." to listOf("projectreactor" to "projectreactor", "zipkin" to "zipkin"),
                 "jakarta." to listOf("" to "jakarta"),
-                "commons-" to
-                    listOf(
-                        "io" to "commons",
-                        "codec" to "commons",
-                        "lang" to "commons",
-                        "logging" to "commons",
-                        "collections" to "commons",
-                    ),
+                "commons-" to listOf("" to "commons"),
                 "androidx." to listOf("" to "androidx"),
             )
 

--- a/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/GeneratorConfig.kt
+++ b/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/GeneratorConfig.kt
@@ -279,29 +279,9 @@ class GeneratorConfig(val settings: Settings) {
 
         /**
          * Default function to generate the prefix of the library's alias. There are a series of
-         * special cases we handle to make the prefix generation "nicer":
-         * 1. The group prefix is `com.fasterxml.jackson`: `jackson`
-         * 2. The group prefix is `com.oracle.database`: `oracle`
-         * 3. The group prefix is `com.google.android`: `android`
-         * 4. The group prefix is `com.facebook`: `facebook`
-         * 5. The group prefix is `org.springframework`: `spring`
-         * 6. The group prefix is `org.hibernate`: `hibernate`
-         * 7. The group prefix is `org.apache.httpcomponents`: `httpcomponents`
-         * 8. The group prefix is `org.apache.tomcat`: `tomcat`
-         * 9. The group prefix is `org.eclipse.jetty`: `jetty`
-         * 10. The group prefix is `org.elasticsearch`: `elasticsearch`
-         * 11. The group prefix is `org.firebirdsql`: `firebird`
-         * 12. The group prefix is `org.glassfish.jersey`: `jersey`
-         * 13. The group prefix is `org.jetbrains.kotlinx`: `kotlinx`
-         * 14. The group prefix is `org.jetbrains.kotlin`: `kotlin`
-         * 15. The group prefix is `org.junit`: `junit`
-         * 16. The group prefix is `org.mariadb`: `mariadb`
-         * 17. The group prefix is `org.neo4j`: `neo4j`
-         * 18. The group prefix is `io.projectreactor`: `projectreactor`
-         * 19. The group prefix is `io.zipkin`: `zipkin`
-         * 20. The group prefix is `jakarta.`: `jakarta`
-         * 21. The group prefix is `commons-`: `commons`
-         * 22. The group prefix is `androidx`: `androidx`
+         * special cases we handle to make the prefix generation "nicer". Please see the
+         * [documentation](https://austinarbor.github.io/version-catalog-generator/#_prefix_generation)
+         * for a list of specially handled prefixes.
          *
          * If none of the above prefixes match, the logic is as follows:
          * 1. The `groupId` is split by `.`

--- a/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/GeneratorConfig.kt
+++ b/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/GeneratorConfig.kt
@@ -390,7 +390,12 @@ class GeneratorConfig(val settings: Settings) {
                         "mariadb" to "mariadb",
                         "neo4j" to "neo4j",
                     ),
-                "io." to listOf("projectreactor" to "projectreactor", "zipkin" to "zipkin"),
+                "io." to
+                    listOf(
+                        "projectreactor" to "projectreactor",
+                        "zipkin" to "zipkin",
+                        "dropwizard" to "dropwizard",
+                    ),
                 "jakarta." to listOf("" to "jakarta"),
                 "commons-" to listOf("" to "commons"),
                 "androidx." to listOf("" to "androidx"),

--- a/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/GeneratorConfig.kt
+++ b/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/GeneratorConfig.kt
@@ -295,11 +295,10 @@ class GeneratorConfig(val settings: Settings) {
         @JvmStatic
         val DEFAULT_ALIAS_PREFIX_GENERATOR: (String, String) -> String = { group, artifact ->
             val (nice, nicePrefix) = nicePrefix(group)
-            if (nice) {
-                nicePrefix
-            } else {
-                val split = group.split(".")
-                if (INVALID_PREFIXES.contains(split.last())) {
+            val split = group.split(".")
+            when {
+                nice -> nicePrefix
+                INVALID_PREFIXES.contains(split.last()) -> {
                     require(split.size >= 2) {
                         "Cannot generate alias for ${group}:${artifact}, please provide custom generator"
                     }
@@ -308,9 +307,8 @@ class GeneratorConfig(val settings: Settings) {
                         CaseFormat.LOWER_HYPHEN,
                         CaseFormat.CAMEL,
                     )
-                } else {
-                    split.last()
                 }
+                else -> split.last()
             }
         }
 

--- a/plugin/src/test/kotlin/dev/aga/gradle/versioncatalogs/GeneratorConfigTest.kt
+++ b/plugin/src/test/kotlin/dev/aga/gradle/versioncatalogs/GeneratorConfigTest.kt
@@ -34,7 +34,7 @@ class GeneratorConfigTest {
                 )
         } else {
             val actual = GeneratorConfig.DEFAULT_ALIAS_PREFIX_GENERATOR(groupId, artifactId)
-            Assertions.assertThat(actual).isEqualTo(expected)
+            assertThat(actual).isEqualTo(expected)
         }
     }
 
@@ -109,7 +109,31 @@ class GeneratorConfigTest {
         private fun defaultAliasPrefixProvider(): List<Arguments> {
             return listOf(
                 arguments("com.fasterxml.jackson", "any-thing", "jackson"),
+                arguments("com.oracle.database.jdbc", "ojdbc8", "oracle"),
+                arguments("com.google.android.material", "material", "android"),
+                arguments("com.facebook.react", "react", "facebook"),
                 arguments("org.springframework.boot", "spring-boot-starter-web", "spring"),
+                arguments("org.hibernate.orm", "hibernate-core", "hibernate"),
+                arguments("org.apache.httpcomponents.client5", "httpclient5", "httpcomponents"),
+                arguments("org.apache.tomcat.embed", "tomcat-embed-core", "tomcat"),
+                arguments("org.eclipse.jetty.ee10", "jetty-ee10-bom", "jetty"),
+                arguments("org.elasticsearch.client", "elasticsearch-rest-client", "elasticsearch"),
+                arguments("org.firebirdsql.jdbc", "jaybird", "firebird"),
+                arguments("org.glassfish.jersey.core", "jersey-client", "jersey"),
+                arguments("org.jetbrains.kotlinx", "anything", "kotlinx"),
+                arguments("org.jetbrains.kotlin", "anything", "kotlin"),
+                arguments("org.junit.jupiter", "junit-jupiter-api", "junit"),
+                arguments("org.mariadb.jdbc", "mariadb-java-client", "mariadb"),
+                arguments("org.neo4j.build", "advanced-build", "neo4j"),
+                arguments("io.projectreactor.rabbitmq", "reactor-rabbitmq", "projectreactor"),
+                arguments("io.zipkin.brave", "brave", "zipkin"),
+                arguments("jakarta.activation", "jakarta.activation-api", "jakarta"),
+                arguments("commons-io", "commons-io", "commons"),
+                arguments("commons-lang", "commons-lang", "commons"),
+                arguments("commons-codec", "commons-codec", "commons"),
+                arguments("commons-logging", "commons-logging", "commons"),
+                arguments("commons-collections", "commons-collections", "commons"),
+                arguments("androidx.appcompat", "appcompat", "androidx"),
                 arguments("dev.aga", "version-catalog-generator", "aga"),
                 arguments("dev.plugins", "anything", "devPlugins"),
                 arguments("plugins", "anything", "error"),

--- a/plugin/src/test/kotlin/dev/aga/gradle/versioncatalogs/GeneratorConfigTest.kt
+++ b/plugin/src/test/kotlin/dev/aga/gradle/versioncatalogs/GeneratorConfigTest.kt
@@ -4,8 +4,8 @@ import dev.aga.gradle.versioncatalogs.GeneratorConfig.Companion.DEFAULT_ALIAS_GE
 import java.io.File
 import java.nio.file.Paths
 import net.pearx.kasechange.CaseFormat
-import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.gradle.api.initialization.Settings
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
@@ -20,14 +20,14 @@ class GeneratorConfigTest {
     @MethodSource("defaultLibraryNameProvider")
     fun `default library alias generator`(group: String, name: String, expected: String) {
         val actual = DEFAULT_ALIAS_GENERATOR(group, name)
-        Assertions.assertThat(actual).isEqualTo(expected)
+        assertThat(actual).isEqualTo(expected)
     }
 
     @ParameterizedTest
     @MethodSource("defaultAliasPrefixProvider")
     fun `default alias prefix generator`(groupId: String, artifactId: String, expected: String) {
         if (expected == "error") {
-            Assertions.assertThatExceptionOfType(IllegalArgumentException::class.java)
+            assertThatExceptionOfType(IllegalArgumentException::class.java)
                 .isThrownBy { GeneratorConfig.DEFAULT_ALIAS_PREFIX_GENERATOR(groupId, artifactId) }
                 .withMessage(
                     "Cannot generate alias for ${groupId}:${artifactId}, please provide custom generator",
@@ -47,27 +47,27 @@ class GeneratorConfigTest {
         expected: String,
     ) {
         val actual = GeneratorConfig.DEFAULT_ALIAS_SUFFIX_GENERATOR(prefix, groupId, artifactId)
-        Assertions.assertThat(actual).isEqualTo(expected)
+        assertThat(actual).isEqualTo(expected)
     }
 
     @Test
     fun testNoAliasPrefix() {
         val actual = GeneratorConfig.NO_PREFIX("whatever", "whatever")
-        Assertions.assertThat(actual).isBlank()
+        assertThat(actual).isBlank()
     }
 
     @ParameterizedTest
     @MethodSource("defaultVersionNameProvider")
     fun `default version name generator`(version: String, expected: String) {
         val actual = GeneratorConfig.DEFAULT_VERSION_NAME_GENERATOR(version)
-        Assertions.assertThat(actual).isEqualTo(expected)
+        assertThat(actual).isEqualTo(expected)
     }
 
     @ParameterizedTest
     @MethodSource("caseChangeProvider")
     fun `case change`(source: String, from: CaseFormat, to: CaseFormat, expected: String) {
         val actual = GeneratorConfig.caseChange(source, from, to)
-        Assertions.assertThat(actual).isEqualTo(expected)
+        assertThat(actual).isEqualTo(expected)
     }
 
     @Test

--- a/plugin/src/test/kotlin/dev/aga/gradle/versioncatalogs/GeneratorConfigTest.kt
+++ b/plugin/src/test/kotlin/dev/aga/gradle/versioncatalogs/GeneratorConfigTest.kt
@@ -127,6 +127,7 @@ class GeneratorConfigTest {
                 arguments("org.neo4j.build", "advanced-build", "neo4j"),
                 arguments("io.projectreactor.rabbitmq", "reactor-rabbitmq", "projectreactor"),
                 arguments("io.zipkin.brave", "brave", "zipkin"),
+                arguments("io.dropwizard.metrics", "metrics", "dropwizard"),
                 arguments("jakarta.activation", "jakarta.activation-api", "jakarta"),
                 arguments("commons-io", "commons-io", "commons"),
                 arguments("commons-lang", "commons-lang", "commons"),

--- a/plugin/src/test/resources/expectations/spring-boot-dependencies/libs.versions.toml
+++ b/plugin/src/test/resources/expectations/spring-boot-dependencies/libs.versions.toml
@@ -25,10 +25,10 @@ spring-springBootStarterActuator = { group = "org.springframework.boot", name = 
 spring-springBootStarterAop = { group = "org.springframework.boot", name = "spring-boot-starter-aop", version = "3.1.2" }
 spring-springBootStarterJdbc = { group = "org.springframework.boot", name = "spring-boot-starter-jdbc", version = "3.1.2" }
 spring-springBootStarterWeb = { group = "org.springframework.boot", name = "spring-boot-starter-web", version = "3.1.2" }
-brave-braveBom = { group = "io.zipkin.brave", name = "brave-bom", version.ref = "brave" }
-brave-brave = { group = "io.zipkin.brave", name = "brave", version = "5.15.1" }
-brave-braveTests = { group = "io.zipkin.brave", name = "brave-tests", version = "5.15.1" }
-brave-braveSpringBeans = { group = "io.zipkin.brave", name = "brave-spring-beans", version = "5.15.1" }
+zipkin-braveBom = { group = "io.zipkin.brave", name = "brave-bom", version.ref = "brave" }
+zipkin-brave = { group = "io.zipkin.brave", name = "brave", version = "5.15.1" }
+zipkin-braveTests = { group = "io.zipkin.brave", name = "brave-tests", version = "5.15.1" }
+zipkin-braveSpringBeans = { group = "io.zipkin.brave", name = "brave-spring-beans", version = "5.15.1" }
 caffeine-caffeine = { group = "com.github.ben-manes.caffeine", name = "caffeine", version.ref = "caffeine" }
 caffeine-guava = { group = "com.github.ben-manes.caffeine", name = "guava", version.ref = "caffeine" }
 caffeine-jcache = { group = "com.github.ben-manes.caffeine", name = "jcache", version.ref = "caffeine" }
@@ -45,16 +45,16 @@ jackson-jacksonJrAll = { group = "com.fasterxml.jackson.jr", name = "jackson-jr-
 jackson-jacksonModuleBlackbird = { group = "com.fasterxml.jackson.module", name = "jackson-module-blackbird", version = "2.15.2" }
 jackson-jacksonModuleKotlin = { group = "com.fasterxml.jackson.module", name = "jackson-module-kotlin", version = "2.15.2" }
 jackson-jacksonModuleScala_211 = { group = "com.fasterxml.jackson.module", name = "jackson-module-scala_2.11", version = "2.15.2" }
-metrics-metricsBom = { group = "io.dropwizard.metrics", name = "metrics-bom", version.ref = "dropwizardMetrics" }
-metrics-metricsAnnotation = { group = "io.dropwizard.metrics", name = "metrics-annotation", version = "4.2.19" }
-metrics-metricsCaffeine = { group = "io.dropwizard.metrics", name = "metrics-caffeine", version = "4.2.19" }
-metrics-metricsCaffeine3 = { group = "io.dropwizard.metrics", name = "metrics-caffeine3", version = "4.2.19" }
-metrics-metricsCore = { group = "io.dropwizard.metrics", name = "metrics-core", version = "4.2.19" }
-reporter2-zipkinReporterBom = { group = "io.zipkin.reporter2", name = "zipkin-reporter-bom", version = "2.16.3" }
-zipkin2-zipkin = { group = "io.zipkin.zipkin2", name = "zipkin", version = "2.23.2" }
-proto3-zipkinProto3 = { group = "io.zipkin.proto3", name = "zipkin-proto3", version = "1.0.0" }
-reporter2-zipkinReporter = { group = "io.zipkin.reporter2", name = "zipkin-reporter", version = "2.16.3" }
-reporter2-zipkinReporterBrave = { group = "io.zipkin.reporter2", name = "zipkin-reporter-brave", version = "2.16.3" }
+dropwizard-metricsBom = { group = "io.dropwizard.metrics", name = "metrics-bom", version.ref = "dropwizardMetrics" }
+dropwizard-metricsAnnotation = { group = "io.dropwizard.metrics", name = "metrics-annotation", version = "4.2.19" }
+dropwizard-metricsCaffeine = { group = "io.dropwizard.metrics", name = "metrics-caffeine", version = "4.2.19" }
+dropwizard-metricsCaffeine3 = { group = "io.dropwizard.metrics", name = "metrics-caffeine3", version = "4.2.19" }
+dropwizard-metricsCore = { group = "io.dropwizard.metrics", name = "metrics-core", version = "4.2.19" }
+zipkin-zipkinReporterBom = { group = "io.zipkin.reporter2", name = "zipkin-reporter-bom", version = "2.16.3" }
+zipkin-zipkin = { group = "io.zipkin.zipkin2", name = "zipkin", version = "2.23.2" }
+zipkin-zipkinProto3 = { group = "io.zipkin.proto3", name = "zipkin-proto3", version = "1.0.0" }
+zipkin-zipkinReporter = { group = "io.zipkin.reporter2", name = "zipkin-reporter", version = "2.16.3" }
+zipkin-zipkinReporterBrave = { group = "io.zipkin.reporter2", name = "zipkin-reporter-brave", version = "2.16.3" }
 
 
 [bundles]

--- a/plugin/src/test/resources/expectations/spring-boot-dependencies/property-overrides.toml
+++ b/plugin/src/test/resources/expectations/spring-boot-dependencies/property-overrides.toml
@@ -25,10 +25,10 @@ spring-springBootStarterActuator = { group = "org.springframework.boot", name = 
 spring-springBootStarterAop = { group = "org.springframework.boot", name = "spring-boot-starter-aop", version = "3.1.2" }
 spring-springBootStarterJdbc = { group = "org.springframework.boot", name = "spring-boot-starter-jdbc", version = "3.1.2" }
 spring-springBootStarterWeb = { group = "org.springframework.boot", name = "spring-boot-starter-web", version = "3.1.2" }
-brave-braveBom = { group = "io.zipkin.brave", name = "brave-bom", version.ref = "brave" }
-brave-brave = { group = "io.zipkin.brave", name = "brave", version = "5.15.1" }
-brave-braveTests = { group = "io.zipkin.brave", name = "brave-tests", version = "5.15.1" }
-brave-braveSpringBeans = { group = "io.zipkin.brave", name = "brave-spring-beans", version = "5.15.1" }
+zipkin-braveBom = { group = "io.zipkin.brave", name = "brave-bom", version.ref = "brave" }
+zipkin-brave = { group = "io.zipkin.brave", name = "brave", version = "5.15.1" }
+zipkin-braveTests = { group = "io.zipkin.brave", name = "brave-tests", version = "5.15.1" }
+zipkin-braveSpringBeans = { group = "io.zipkin.brave", name = "brave-spring-beans", version = "5.15.1" }
 caffeine-caffeine = { group = "com.github.ben-manes.caffeine", name = "caffeine", version.ref = "caffeine" }
 caffeine-guava = { group = "com.github.ben-manes.caffeine", name = "guava", version.ref = "caffeine" }
 caffeine-jcache = { group = "com.github.ben-manes.caffeine", name = "jcache", version.ref = "caffeine" }
@@ -45,16 +45,16 @@ jackson-jacksonJrAll = { group = "com.fasterxml.jackson.jr", name = "jackson-jr-
 jackson-jacksonModuleBlackbird = { group = "com.fasterxml.jackson.module", name = "jackson-module-blackbird", version = "2.16.1" }
 jackson-jacksonModuleKotlin = { group = "com.fasterxml.jackson.module", name = "jackson-module-kotlin", version = "2.16.1" }
 jackson-jacksonModuleScala_211 = { group = "com.fasterxml.jackson.module", name = "jackson-module-scala_2.11", version = "2.16.1" }
-metrics-metricsBom = { group = "io.dropwizard.metrics", name = "metrics-bom", version.ref = "dropwizardMetrics" }
-metrics-metricsAnnotation = { group = "io.dropwizard.metrics", name = "metrics-annotation", version = "4.2.19" }
-metrics-metricsCaffeine = { group = "io.dropwizard.metrics", name = "metrics-caffeine", version = "4.2.19" }
-metrics-metricsCaffeine3 = { group = "io.dropwizard.metrics", name = "metrics-caffeine3", version = "4.2.19" }
-metrics-metricsCore = { group = "io.dropwizard.metrics", name = "metrics-core", version = "4.2.19" }
-reporter2-zipkinReporterBom = { group = "io.zipkin.reporter2", name = "zipkin-reporter-bom", version = "2.16.3" }
-zipkin2-zipkin = { group = "io.zipkin.zipkin2", name = "zipkin", version = "2.23.2" }
-proto3-zipkinProto3 = { group = "io.zipkin.proto3", name = "zipkin-proto3", version = "1.0.0" }
-reporter2-zipkinReporter = { group = "io.zipkin.reporter2", name = "zipkin-reporter", version = "2.16.3" }
-reporter2-zipkinReporterBrave = { group = "io.zipkin.reporter2", name = "zipkin-reporter-brave", version = "2.16.3" }
+dropwizard-metricsBom = { group = "io.dropwizard.metrics", name = "metrics-bom", version.ref = "dropwizardMetrics" }
+dropwizard-metricsAnnotation = { group = "io.dropwizard.metrics", name = "metrics-annotation", version = "4.2.19" }
+dropwizard-metricsCaffeine = { group = "io.dropwizard.metrics", name = "metrics-caffeine", version = "4.2.19" }
+dropwizard-metricsCaffeine3 = { group = "io.dropwizard.metrics", name = "metrics-caffeine3", version = "4.2.19" }
+dropwizard-metricsCore = { group = "io.dropwizard.metrics", name = "metrics-core", version = "4.2.19" }
+zipkin-zipkinReporterBom = { group = "io.zipkin.reporter2", name = "zipkin-reporter-bom", version = "2.16.3" }
+zipkin-zipkin = { group = "io.zipkin.zipkin2", name = "zipkin", version = "2.23.2" }
+zipkin-zipkinProto3 = { group = "io.zipkin.proto3", name = "zipkin-proto3", version = "1.0.0" }
+zipkin-zipkinReporter = { group = "io.zipkin.reporter2", name = "zipkin-reporter", version = "2.16.3" }
+zipkin-zipkinReporterBrave = { group = "io.zipkin.reporter2", name = "zipkin-reporter-brave", version = "2.16.3" }
 
 
 [bundles]


### PR DESCRIPTION
# Description
Add more specially handled prefixes 

| Group Prefix | Generated Prefix |
|--------|--------|
| com.fasterxml.jackson | jackson |
| com.oracle.database | oracle |
| com.google.android | android |
| com.facebook | facebook |
| org.springframework | spring | 
| org.hibernate | hibernate | 
| org.apache.httpcomponents | httpcomponents | 
| org.apache.tomcat | tomcat | 
| org.eclipse.jetty | jetty | 
| org.elasticsearch | elasticsearch | 
| org.firebirdsql | firebird |
| org.glassfish.jersey | jersey |
| org.jetbrains.kotlinx | kotlinx |
| org.jetbrains.kotlin | kotlin | 
| org.junit | junit |
| org.mariadb | mariadb |
| org.neo4j | neo4j |
| io.projectreactor | projectreactor |
| io.zipkin | zipkin |
| io.dropwizard | dropwizard |
| jakarta. | jakarta |
| commons- | commons |
| androidx | androidx |