### PR TITLE
Add Ability to Include Extra Dependencies

### DIFF
--- a/plugin/src/docs/asciidoc/detailed-usage.adoc
+++ b/plugin/src/docs/asciidoc/detailed-usage.adoc
@@ -3,6 +3,7 @@
 include::{docdir}/detailed-usage/applying.adoc[]
 include::{docdir}/detailed-usage/existing-catalog.adoc[]
 include::{docdir}/detailed-usage/sources.adoc[]
+include::{docdir}/detailed-usage/additional-dependencies.adoc[]
 include::{docdir}/detailed-usage/bom-entry.adoc[]
 include::{docdir}/detailed-usage/nested-bom-entry.adoc[]
 include::{docdir}/detailed-usage/naming.adoc[]

--- a/plugin/src/docs/asciidoc/detailed-usage/additional-dependencies.adoc
+++ b/plugin/src/docs/asciidoc/detailed-usage/additional-dependencies.adoc
@@ -1,0 +1,65 @@
+
+=== Including Additional Dependencies in the Generated Catalog
+
+Sometimes you may want to include dependencies in the generated catalog that may not be declared
+in the BOM(s) you are generated from. For example, `mockito-bom` does not include `mockito-kotlin`
+in its `dependencyManagement` section, so it would be cumbersome (or impossible) to include this dependency
+with your generated catalog and access it in a single place, or to include that dependency in a bundle.
+
+To include additional dependencies, you can either use `withDep`, `withDeps`, or `withDepsFromToml`.
+
+.settings.gradle.kts
+[source,kotlin,subs="attributes+",role="primary"]
+----
+import dev.aga.gradle.versioncatalogs.Generator.generate
+
+plugins {
+  id("dev.aga.gradle.version-catalog-generator") version "{version}"
+}
+
+dependencyResolutionManagement {
+  versionCatalogs {
+    generate("testingLibs") {
+      fromToml("junit-bom", "mockito-bom", "assertj-bom") {
+        withDepsFromToml("mockito-kotlin") // <1>
+        withDep("org.mockito.kotlin", "mockito-kotlin", "6.1.0") // <2>
+        withDeps("org.mockito.kotlin:mockito-kotlin:6.1.0") // <3>
+      }
+    }
+  }
+}
+----
+<1> Include the dependency associated with the specified alias(es) in the generated catalog
+<2> Include an extra dependency specified by its group, name, and version
+<3> Include one or more extra dependencies specified their shorthand concatenated notation
+
+.settings.gradle
+[source,groovy,subs="attributes+",role="secondary"]
+----
+plugins {
+  id 'dev.aga.gradle.version-catalog-generator' version '{version}'
+}
+
+dependencyResolutionManagement {
+  versionCatalogs {
+    generator.generate("testingLibs") {
+      it.from { from ->
+        from.toml { toml ->
+          toml.libraryAliases = ["junit-bom", "mockito-bom", "assertj-bom"]
+        }
+        from.using { using ->
+          using.withDepsFromToml("mockito-kotlin") // <1>
+          using.withDep("org.mockito.kotlin", "mockito-kotlin", "6.1.0") // <2>
+          using.withDeps("org.mockito.kotlin:mockito-kotlin:6.1.0") // <3>
+        }
+      }
+    }
+  }
+}
+----
+<1> Include the dependency associated with the specified alias(es) in the generated catalog
+<2> Include an extra dependency specified by its group, name, and version
+<3> Include one or more extra dependencies specified their shorthand concatenated notation
+
+IMPORTANT: When using `withDepsFromToml`, you _must_ be loading a BOM from a catalog file within that block, and
+the version alias _must_ exist in that same catalog.

--- a/plugin/src/docs/asciidoc/detailed-usage/existing-catalog.adoc
+++ b/plugin/src/docs/asciidoc/detailed-usage/existing-catalog.adoc
@@ -4,6 +4,8 @@
 .settings.gradle.kts
 [source,kotlin,subs="attributes+",role="primary"]
 ----
+import dev.aga.gradle.versioncatalogs.Generator.generate // <1>
+
 plugins {
   id("dev.aga.gradle.version-catalog-generator") version "{version}"
 }

--- a/plugin/src/docs/asciidoc/detailed-usage/existing-catalog.adoc
+++ b/plugin/src/docs/asciidoc/detailed-usage/existing-catalog.adoc
@@ -4,8 +4,6 @@
 .settings.gradle.kts
 [source,kotlin,subs="attributes+",role="primary"]
 ----
-import dev.aga.gradle.versioncatalogs.Generator.generate // <1>
-
 plugins {
   id("dev.aga.gradle.version-catalog-generator") version "{version}"
 }

--- a/plugin/src/docs/asciidoc/detailed-usage/existing-catalog.adoc
+++ b/plugin/src/docs/asciidoc/detailed-usage/existing-catalog.adoc
@@ -4,7 +4,7 @@
 .settings.gradle.kts
 [source,kotlin,subs="attributes+",role="primary"]
 ----
-import dev.aga.gradle.versioncatalogs.Generator.generate // <1>
+import dev.aga.gradle.versioncatalogs.Generator.generate
 
 plugins {
   id("dev.aga.gradle.version-catalog-generator") version "{version}"

--- a/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/GeneratorConfig.kt
+++ b/plugin/src/main/kotlin/dev/aga/gradle/versioncatalogs/GeneratorConfig.kt
@@ -544,15 +544,29 @@ class GeneratorConfig(val settings: Settings) {
      */
     fun versionRef(alias: String): TomlVersionRef = TomlVersionRef(alias, catalogParserSupplier)
 
+    /**
+     * Add a dependency that cannot be found from the imported BOM by the dependency's group, name,
+     * and version.
+     */
     fun withDep(group: String, name: String, version: String) =
-      withDep("${group}:${name}:${version}")
+      withDeps("${group}:${name}:${version}")
 
-    fun withDep(notation: String) {
-      extraDeps += { notation.toDependency() }
+    /**
+     * Add one or more dependencies that cannot be found from the imported BOM by the dependency's
+     * by specifying their concatenated notation `${group}:${name}:${version}`
+     */
+    fun withDeps(vararg notation: String) {
+      notation.forEach { extraDeps += { it.toDependency() } }
     }
 
-    fun withDepFromToml(alias: String) {
-      extraDeps += { catalogParserSupplier().findLibrary(alias) }
+    /**
+     * Add additional dependencies that cannot be found from the imported BOM by their alias in an
+     * existing version catalog. The catalog to find them must be the same catalog that is used to
+     * find one or more BOMs from this declaration. If no BOMs are looked up from a TOML in this
+     * declaration, an exception will be thrown.
+     */
+    fun withDepsFromToml(vararg alias: String) {
+      alias.forEach { extraDeps += { catalogParserSupplier().findLibrary(it) } }
     }
 
     /**

--- a/plugin/src/test/kotlin/dev/aga/gradle/versioncatalogs/VersionCatalogGeneratorPluginTest.kt
+++ b/plugin/src/test/kotlin/dev/aga/gradle/versioncatalogs/VersionCatalogGeneratorPluginTest.kt
@@ -117,6 +117,30 @@ class VersionCatalogGeneratorPluginTest {
                     aliasPrefixGenerator = GeneratorConfig.NO_PREFIX
                   }
                 }
+                generate("testingLibs") {
+                  saveGeneratedCatalog = true
+                  fromToml("junit-bom", "assertj-bom", "mockito-bom") {
+                    aliasPrefixGenerator = GeneratorConfig.NO_PREFIX
+                    withDepsFromToml("mockito-kotlin")
+                  }
+                  fromToml("kotlinx-coroutines-bom") {
+                    aliasPrefixGenerator = GeneratorConfig.NO_PREFIX
+                    filter = { it.artifactId.endsWith("-test") }
+                  }
+                  bundleMapping = {
+                    when {
+                      it.alias in listOf(
+                        "junitJupiter", 
+                        "junitPlatformLauncher",
+                        "mockitoCore", 
+                        "mockitoJunitJupiter", 
+                        "mockitoKotlin", 
+                        "assertjCore",
+                      ) -> "testing"
+                      else -> null
+                    }
+                  }
+                }
               }
             }
         """
@@ -141,6 +165,13 @@ class VersionCatalogGeneratorPluginTest {
         testImplementation(mockitoLibs.mockito.junit.jupiter)
         testImplementation(junitLibs.junitJupiter)
         testImplementation(junitLibs.junitJupiterParams)
+        testImplementation(testingLibs.junitJupiter)
+        testImplementation(testingLibs.mockitoCore)
+        testImplementation(testingLibs.mockitoJunitJupiter)
+        testImplementation(testingLibs.mockitoKotlin)
+        testImplementation(testingLibs.assertjCore)
+        testImplementation(testingLibs.kotlinxCoroutinesTest)
+        testImplementation(testingLibs.bundles.testing)
       }
       """
         .trimIndent()
@@ -152,10 +183,21 @@ class VersionCatalogGeneratorPluginTest {
           aws = "2.21.15"
           jackson = "2.18.2"
           spring = "3.4.1"
+          mockito = "5.20.0"
+          mockito-kotlin = "6.1.0"
+          junit = "6.0.0"
+          assertj = "3.27.6"
+          kotlinx-coroutines = "1.10.2"
+       
           [libraries]
           aws-bom = { group = "software.amazon.awssdk", name = "bom", version.ref = "aws"}
           jackson-bom = { group = "com.fasterxml.jackson", name = "jackson-bom", version.ref = "jackson" }
           spring-boot-dependencies = { group = "org.springframework.boot", name = "spring-boot-dependencies", version.ref = "spring" }
+          junit-bom = { group = "org.junit", name = "junit-bom", version.ref = "junit" }
+          mockito-bom = { group = "org.mockito", name = "mockito-bom", version.ref = "mockito" }
+          mockito-kotlin = { group = "org.mockito.kotlin", name = "mockito-kotlin", version.ref = "mockito-kotlin" } 
+          assertj-bom = { group = "org.assertj", name = "assertj-bom", version.ref = "assertj" }
+          kotlinx-coroutines-bom = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-bom", version.ref = "kotlinx-coroutines" }
       """
         .trimIndent()
     )
@@ -178,6 +220,7 @@ class VersionCatalogGeneratorPluginTest {
       .isDirectoryContaining { it.name == "jsonLibs.versions.toml" }
       .isDirectoryContaining { it.name == "junitLibs.versions.toml" }
       .isDirectoryContaining { it.name == "mockitoLibs.versions.toml" }
+      .isDirectoryContaining { it.name == "testingLibs.versions.toml" }
   }
 
   @Test
@@ -263,6 +306,35 @@ class VersionCatalogGeneratorPluginTest {
                     }
                   }
                 }
+                
+                generator.generate("testingLibs") {
+                  it.saveGeneratedCatalog = true
+                  it.from { from ->
+                    from.toml { toml ->
+                      toml.libraryAliases = ["junit-bom", "assertj-bom", "mockito-bom"]
+                    }
+                    from.using { u ->
+                      u.aliasPrefixGenerator = NO_PREFIX
+                      u.withDepsFromToml("mockito-kotlin")
+                    }
+                  }
+                  it.from { from -> 
+                    from.toml { toml ->
+                      toml.libraryAliases = ["kotlinx-coroutines-bom"]
+                    }
+                    from.using { u ->
+                      u.aliasPrefixGenerator = NO_PREFIX
+                      u.filter = { it.artifactId.endsWith("-test") }
+                    }
+                  }
+                  it.bundleMapping = {
+                    if(it.alias in ["junitJupiter", "junitPlatformLauncher", "mockitoCore", "mockitoJunitJupiter", "mockitoKotlin", "assertjCore" ]) {
+                      "testing"
+                    } else {
+                      null
+                    }
+                  }
+                }
               }
             }
         """
@@ -279,6 +351,13 @@ class VersionCatalogGeneratorPluginTest {
         implementation(jsonLibs.bundles.jacksonModule)
         testImplementation(mockitoLibs.mockito.mockitoCore)
         testImplementation(junitLibs.junitJupiter)
+        testImplementation(testingLibs.junitJupiter)
+        testImplementation(testingLibs.mockitoCore)
+        testImplementation(testingLibs.mockitoJunitJupiter)
+        testImplementation(testingLibs.mockitoKotlin)
+        testImplementation(testingLibs.assertjCore)
+        testImplementation(testingLibs.kotlinxCoroutinesTest)
+        testImplementation(testingLibs.bundles.testing)
       }
       """
         .trimIndent()
@@ -290,10 +369,21 @@ class VersionCatalogGeneratorPluginTest {
           aws = "2.21.15"
           jackson = "2.18.2"
           spring = "3.4.1"
+          mockito = "5.20.0"
+          mockito-kotlin = "6.1.0"
+          junit = "6.0.0"
+          assertj = "3.27.6"
+          kotlinx-coroutines = "1.10.2"
+          
           [libraries]
           aws-bom = { group = "software.amazon.awssdk", name = "bom", version.ref = "aws"}
           jackson-bom = { group = "com.fasterxml.jackson", name = "jackson-bom", version.ref = "jackson" }
           spring-boot-dependencies = { group = "org.springframework.boot", name = "spring-boot-dependencies", version.ref = "spring" }
+          junit-bom = { group = "org.junit", name = "junit-bom", version.ref = "junit" }
+          mockito-bom = { group = "org.mockito", name = "mockito-bom", version.ref = "mockito" }
+          mockito-kotlin = { group = "org.mockito.kotlin", name = "mockito-kotlin", version.ref = "mockito-kotlin" } 
+          assertj-bom = { group = "org.assertj", name = "assertj-bom", version.ref = "assertj" }
+          kotlinx-coroutines-bom = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-bom", version.ref = "kotlinx-coroutines" }
       """
         .trimIndent()
     )

--- a/plugin/src/test/resources/expectations/additional-deps/libs.versions.toml
+++ b/plugin/src/test/resources/expectations/additional-deps/libs.versions.toml
@@ -1,0 +1,14 @@
+[versions]
+
+[libraries]
+junitJupiter = { group = "org.junit.jupiter", name = "junit-jupiter", version = "5.11.4" }
+junitJupiterApi = { group = "org.junit.jupiter", name = "junit-jupiter-api", version = "5.11.4" }
+junitJupiterEngine = { group = "org.junit.jupiter", name = "junit-jupiter-engine", version = "5.11.4" }
+junitPlatformEngine = { group = "org.junit.platform", name = "junit-platform-engine", version = "1.11.4" }
+assertjCore = { group = "org.assertj", name = "assertj-core", version = "3.25.3" }
+assertjGuava = { group = "org.assertj", name = "assertj-guava", version = "3.25.3" }
+mockitoKotlin = { group = "org.mockito.kotlin", name = "mockito-kotlin", version = "6.1.0" }
+
+[bundles]
+
+[plugins]

--- a/plugin/src/test/resources/expectations/additional-deps/testingLibs.versions.toml
+++ b/plugin/src/test/resources/expectations/additional-deps/testingLibs.versions.toml
@@ -1,0 +1,18 @@
+[versions]
+
+[libraries]
+junitJupiter = { group = "org.junit.jupiter", name = "junit-jupiter", version = "5.11.4" }
+junitJupiterApi = { group = "org.junit.jupiter", name = "junit-jupiter-api", version = "5.11.4" }
+junitJupiterEngine = { group = "org.junit.jupiter", name = "junit-jupiter-engine", version = "5.11.4" }
+junitPlatformEngine = { group = "org.junit.platform", name = "junit-platform-engine", version = "1.11.4" }
+assertjCore = { group = "org.assertj", name = "assertj-core", version = "3.25.3" }
+assertjGuava = { group = "org.assertj", name = "assertj-guava", version = "3.25.3" }
+mockitoCore = { group = "org.mockito", name = "mockito-core", version = "5.20.0" }
+mockitoJunitJupiter = { group = "org.mockito", name = "mockito-junit-jupiter", version = "5.20.0" }
+mockitoKotlin = { group = "org.mockito.kotlin", name = "mockito-kotlin", version = "6.1.0" }
+kotlinxCoroutinesTest = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version = "1.10.2" }
+
+[bundles]
+testing = ["junitJupiter", "mockitoCore", "mockitoJunitJupiter", "mockitoKotlin", "assertjCore"]
+
+[plugins]

--- a/plugin/src/test/resources/poms/kotlinx-coroutines-bom-1.10.2.pom
+++ b/plugin/src/test/resources/poms/kotlinx-coroutines-bom-1.10.2.pom
@@ -1,0 +1,57 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.jetbrains.kotlinx</groupId>
+    <artifactId>kotlinx-coroutines-bom</artifactId>
+    <version>1.10.2</version>
+    <packaging>pom</packaging>
+    <name>kotlinx-coroutines-bom</name>
+    <description>Coroutines support libraries for Kotlin</description>
+    <url>https://github.com/Kotlin/kotlinx.coroutines</url>
+    <licenses>
+        <license>
+            <name>Apache-2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+    <developers>
+        <developer>
+            <id>JetBrains</id>
+            <name>JetBrains Team</name>
+            <organization>JetBrains</organization>
+            <organizationUrl>https://www.jetbrains.com</organizationUrl>
+        </developer>
+    </developers>
+    <scm>
+        <url>https://github.com/Kotlin/kotlinx.coroutines</url>
+    </scm>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.jetbrains.kotlinx</groupId>
+                <artifactId>kotlinx-coroutines-core-jvm</artifactId>
+                <version>1.10.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jetbrains.kotlinx</groupId>
+                <artifactId>kotlinx-coroutines-core</artifactId>
+                <version>1.10.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jetbrains.kotlinx</groupId>
+                <artifactId>kotlinx-coroutines-slf4j</artifactId>
+                <version>1.10.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jetbrains.kotlinx</groupId>
+                <artifactId>kotlinx-coroutines-test-jvm</artifactId>
+                <version>1.10.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jetbrains.kotlinx</groupId>
+                <artifactId>kotlinx-coroutines-test</artifactId>
+                <version>1.10.2</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/plugin/src/test/resources/poms/mockito-bom-5.20.0.pom
+++ b/plugin/src/test/resources/poms/mockito-bom-5.20.0.pom
@@ -1,0 +1,76 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.mockito</groupId>
+    <artifactId>mockito-bom</artifactId>
+    <version>5.20.0</version>
+    <packaging>pom</packaging>
+    <name>mockito-bom</name>
+    <description>Mockito Bill of Materials (BOM)</description>
+    <url>https://github.com/mockito/mockito</url>
+    <licenses>
+        <license>
+            <name>MIT</name>
+            <url>https://opensource.org/licenses/MIT</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+    <developers>
+        <developer>
+            <id>mockitoguy</id>
+            <name>Szczepan Faber</name>
+            <url>https://github.com/mockitoguy</url>
+            <roles>
+                <role>Core developer</role>
+            </roles>
+        </developer>
+        <developer>
+            <id>bric3</id>
+            <name>Brice Dutheil</name>
+            <url>https://github.com/bric3</url>
+            <roles>
+                <role>Core developer</role>
+            </roles>
+        </developer>
+        <developer>
+            <id>raphw</id>
+            <name>Rafael Winterhalter</name>
+            <url>https://github.com/raphw</url>
+            <roles>
+                <role>Core developer</role>
+            </roles>
+        </developer>
+        <developer>
+            <id>TimvdLippe</id>
+            <name>Tim van der Lippe</name>
+            <url>https://github.com/TimvdLippe</url>
+            <roles>
+                <role>Core developer</role>
+            </roles>
+        </developer>
+    </developers>
+    <scm>
+        <url>https://github.com/mockito/mockito.git</url>
+    </scm>
+    <issueManagement>
+        <system>GitHub issues</system>
+        <url>https://github.com/mockito/mockito/issues</url>
+    </issueManagement>
+    <ciManagement>
+        <system>GH Actions</system>
+        <url>https://github.com/mockito/mockito/actions</url>
+    </ciManagement>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>5.20.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-junit-jupiter</artifactId>
+                <version>5.20.0</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/plugin/src/test/resources/tomls/additional-deps.toml
+++ b/plugin/src/test/resources/tomls/additional-deps.toml
@@ -1,0 +1,13 @@
+[versions]
+junit = "5.11.4"
+assertj = "3.25.3"
+mockito = "5.20.0"
+mockito-kotlin = "6.1.0"
+kotlinx-coroutines = "1.10.2"
+
+[libraries]
+junit-bom = { group = "org.junit", name = "junit-bom", version.ref = "junit" }
+assertj-bom = { group = "org.assertj", name = "assertj-bom", version.ref = "assertj" }
+mockito-bom = { group = "org.mockito", name = "mockito-bom", version.ref = "mockito" }
+mockito-kotlin = { group = "org.mockito.kotlin", name = "mockito-kotlin", version.ref = "mockito-kotlin" }
+kotlinx-coroutines-bom = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-bom", version.ref = "kotlinx-coroutines" }


### PR DESCRIPTION
# Description
Adds the ability to include extra dependencies in the generated catalog that may not be in the BOM(s) being generated from

Relates to https://github.com/austinarbor/version-catalog-generator/issues/205