### PR TITLE
Don't Bundle kotlin-stdlib

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -108,7 +108,14 @@ idea {
 }
 
 tasks {
-  shadowJar { archiveClassifier = "" }
+  shadowJar {
+    archiveClassifier = ""
+    dependencies {
+      // kasechange brings in kotlin-stdlib from transitive dependencies
+      exclude(dependency("org.jetbrains.kotlin:.*"))
+      exclude(dependency("org.jetbrains:annotations"))
+    }
+  }
   withType<Detekt>().configureEach {
     // exclude the mock classes from detekt
     exclude("dev/aga/gradle/versioncatalogs/mock/**")


### PR DESCRIPTION
# Description
Version 0.0.6 added kasechange as a dependency. kasechznge itself has kotlin as a transitive dependency. Consequently, the shadow jar task started bundling kotlin-stdlib into the plugin and we need to remove it.

